### PR TITLE
Add User-Agent header

### DIFF
--- a/mailtrap/client.py
+++ b/mailtrap/client.py
@@ -43,6 +43,9 @@ class MailtrapClient:
         return {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
+            "User-Agent": (
+                "mailtrap-python (https://github.com/railsware/mailtrap-python)"
+            ),
         }
 
     @staticmethod

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -41,6 +41,9 @@ class TestMailtrapClient:
         assert client.headers == {
             "Authorization": "Bearer fake_token",
             "Content-Type": "application/json",
+            "User-Agent": (
+                "mailtrap-python (https://github.com/railsware/mailtrap-python)"
+            ),
         }
 
     @responses.activate


### PR DESCRIPTION
## Motivation

-`#goal` add `User-Agent` header to all requests

## Changes

- add `User-Agent` header to `MailtrapClient.headers` property

## How to test

- [ ] Requests sent by the `mailtrap-python` package are with **"User-Agent" = "mailtrap-python (https://github.com/railsware/mailtrap-python)"** header
