### PR TITLE
Resolve build on latest macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,21 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+        # Workaround from https://github.com/actions/runner-images/issues/9770
+        exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
+          - python: "3.6"
+            os: macos-latest
+          - python: "3.7"
+            os: macos-latest
+        include:  # So run those legacy versions on Intel CPUs.
+          - python: "3.6"
+            os: macos-13
+          - python: "3.7"
+            os: macos-13
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox


### PR DESCRIPTION
## Motivation

Build is currently failing because some versions of Python will not install on the `macos-latest` image

## Changes

- Apply workaround found in https://github.com/actions/runner-images/issues/9770. It seems logical.
- Update outdated workflow actions

## How to test

- No testing needed, toolchain only change
