### PR TITLE
Add email templates API support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.2.0] - 2025-05-20
+Add Email Templates API support in MailtrapClient
+
 ## [2.1.0] - 2025-05-12
 - Add sandbox mode support in MailtrapClient
   - It requires inbox_id parameter to be set

--- a/README.md
+++ b/README.md
@@ -122,6 +122,44 @@ client = mt.MailtrapClient(token="your-api-key")
 client.send(mail)
 ```
 
+### Managing templates
+
+You can manage templates stored in your Mailtrap account using `MailtrapClient`.
+When creating a template the following fields are required:
+
+- `name`
+- `subject`
+- `category`
+
+Optional fields are `body_html` and `body_text`.
+
+```python
+import mailtrap as mt
+
+client = mt.MailtrapClient(token="your-api-key")
+
+# list templates
+templates = client.email_templates(account_id=1)
+
+# create template
+new_template = mt.EmailTemplate(
+    name="Welcome",
+    subject="subject",
+    category="Promotion",
+)
+created = client.create_email_template(1, new_template)
+
+# update template
+updated = client.update_email_template(
+    1,
+    created["id"],
+    mt.EmailTemplate(name="Welcome", subject="subject", category="Promotion", body_html="<div>Hi</div>")
+)
+
+# delete template
+client.delete_email_template(1, created["id"])
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on [GitHub](https://github.com/railsware/mailtrap-python). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](CODE_OF_CONDUCT.md).

--- a/mailtrap/__init__.py
+++ b/mailtrap/__init__.py
@@ -1,4 +1,5 @@
 from .client import MailtrapClient
+from .email_template import EmailTemplate
 from .exceptions import APIError
 from .exceptions import AuthorizationError
 from .exceptions import ClientConfigurationError

--- a/mailtrap/email_template.py
+++ b/mailtrap/email_template.py
@@ -1,0 +1,32 @@
+from typing import Any
+from typing import Optional
+
+from mailtrap.mail.base_entity import BaseEntity
+
+
+class EmailTemplate(BaseEntity):
+    def __init__(
+        self,
+        name: str,
+        subject: str,
+        category: str,
+        body_html: Optional[str] = None,
+        body_text: Optional[str] = None,
+    ) -> None:
+        self.name = name
+        self.subject = subject
+        self.category = category
+        self.body_html = body_html
+        self.body_text = body_text
+
+    @property
+    def api_data(self) -> dict[str, Any]:
+        return self.omit_none_values(
+            {
+                "name": self.name,
+                "subject": self.subject,
+                "category": self.category,
+                "body_html": self.body_html,
+                "body_text": self.body_text,
+            }
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mailtrap"
-version = "2.1.0"
+version = "2.2.0"
 description = "Official mailtrap.io API client"
 readme = "README.md"
 license = {file = "LICENSE.txt"}


### PR DESCRIPTION
## Summary
- add `EmailTemplate` model for template requests
- extend `MailtrapClient` template methods to accept the new model
- improve README instructions with required fields and examples
- cover template methods with error handling tests

## Testing
- `pre-commit run --files mailtrap/client.py mailtrap/email_template.py mailtrap/__init__.py README.md tests/unit/test_client.py CHANGELOG.md pyproject.toml`
- `.tox/py311/bin/pytest -q`