### PR TITLE
Fix for issue #29: Add support of Emails Sandbox (Testing) API: Projects

### DIFF
--- a/mailtrap/__init__.py
+++ b/mailtrap/__init__.py
@@ -10,3 +10,6 @@ from .mail import BaseMail
 from .mail import Disposition
 from .mail import Mail
 from .mail import MailFromTemplate
+from .project import BaseProject
+from .project import Name
+from .project import Project

--- a/mailtrap/project/__init__.py
+++ b/mailtrap/project/__init__.py
@@ -1,0 +1,3 @@
+from .base import BaseProject
+from .name import Name
+from .project import Project

--- a/mailtrap/project/base.py
+++ b/mailtrap/project/base.py
@@ -1,0 +1,27 @@
+from abc import ABCMeta
+from collections.abc import Sequence
+from typing import Any
+from typing import Optional
+
+from mailtrap.project.name import Name
+from mailtrap.mail.base_entity import BaseEntity
+
+
+class BaseProject(BaseEntity, metaclass=ABCMeta):
+    """Base abstract class for projects."""
+
+    def __init__(
+        self,
+        project: Optional[Name] = None
+
+    ) -> None:
+        self.project = project
+
+    @property
+    def api_data(self) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+
+        if self.project is not None:
+            data["project"] = self.project.api_data
+
+        return self.omit_none_values(data)

--- a/mailtrap/project/name.py
+++ b/mailtrap/project/name.py
@@ -1,0 +1,13 @@
+from typing import Any
+from typing import Optional
+
+from mailtrap.mail.base_entity import BaseEntity
+
+
+class Name(BaseEntity):
+    def __init__(self, name: Optional[str] = None) -> None:
+        self.name = name
+
+    @property
+    def api_data(self) -> dict[str, Any]:
+        return self.omit_none_values({"name": self.name})

--- a/mailtrap/project/project.py
+++ b/mailtrap/project/project.py
@@ -1,0 +1,26 @@
+from typing import Any
+from typing import Optional
+
+from mailtrap.project.base import BaseProject
+from mailtrap.project.name import Name
+
+
+class Project(BaseProject):
+    """Creates a request body for /api/accounts/{account_id}/projects Mailtrap API v2 endpoint.
+    """
+
+    def __init__(
+        self,
+        project: Optional[Name] = None
+    ) -> None:
+        super().__init__(
+            project=project,
+        )
+
+    @property
+    def api_data(self) -> dict[str, Any]:
+        return self.omit_none_values(
+            {
+                **super().api_data,
+            }
+        )


### PR DESCRIPTION
https://github.com/railsware/mailtrap-python/issues/29
Closes #29

Implemented support for creating new projects using Mailtrap API v2. Added validation to ensure that  is present in sandbox mode. Introduced abstract classes for the project and its name. These abstract classes can be further extended to support interaction with inboxes in the future.
