### PR TITLE
Issue 28

### DIFF
--- a/examples/contacts/contact_fields.py
+++ b/examples/contacts/contact_fields.py
@@ -4,8 +4,8 @@ import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.contacts import ContactField
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
 contact_fields_api = client.contacts_api.contact_fields

--- a/examples/contacts/contact_imports.py
+++ b/examples/contacts/contact_imports.py
@@ -1,8 +1,8 @@
 import mailtrap as mt
 from mailtrap.models.contacts import ContactImport
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
 contact_imports_api = client.contacts_api.contact_imports

--- a/examples/contacts/contact_lists.py
+++ b/examples/contacts/contact_lists.py
@@ -2,8 +2,8 @@ import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.contacts import ContactList
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
 contact_lists_api = client.contacts_api.contact_lists

--- a/examples/contacts/contacts.py
+++ b/examples/contacts/contacts.py
@@ -5,8 +5,8 @@ import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.contacts import Contact
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
 contacts_api = client.contacts_api.contacts

--- a/examples/email_templates/templates.py
+++ b/examples/email_templates/templates.py
@@ -4,8 +4,8 @@ import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.templates import EmailTemplate
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
 templates_api = client.email_templates_api.templates

--- a/examples/sending.py
+++ b/examples/sending.py
@@ -1,6 +1,6 @@
 import mailtrap as mt
 
-API_TOKEN = "<YOU_API_TOKEN>"
+API_TOKEN = "<YOUR_API_TOKEN>"
 INBOX_ID = "<YOUR_INBOX_ID>"
 
 
@@ -19,7 +19,7 @@ mail = mt.Mail(
 mail_from_template = mt.MailFromTemplate(
     sender=mt.Address(email="<SENDER_EMAIL>", name="<SENDER_NAME>"),
     to=[mt.Address(email="<RECEIVER_EMAIL>")],
-    template_uuid="<YOUT_TEMPLATE_UUID>",
+    template_uuid="<YOUR_TEMPLATE_UUID>",
     template_variables={
         "company_info_name": "Test_Company_info_name",
         "name": "Test_Name",

--- a/examples/suppressions/suppressions.py
+++ b/examples/suppressions/suppressions.py
@@ -3,8 +3,8 @@ from typing import Optional
 import mailtrap as mt
 from mailtrap.models.suppressions import Suppression
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
 suppressions_api = client.suppressions_api.suppressions

--- a/examples/testing/attachments.py
+++ b/examples/testing/attachments.py
@@ -1,0 +1,27 @@
+import mailtrap as mt
+from mailtrap.models.attachments import Attachment
+
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+INBOX_ID = "YOUR_INBOX_ID"
+MESSAGE_ID = "YOUR_MESSAGE_ID"
+
+client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+attachments_api = client.testing_api.attachments
+
+
+def list_attachments(inbox_id: int, message_id: int) -> list[Attachment]:
+    return attachments_api.get_list(inbox_id=inbox_id, message_id=message_id)
+
+
+def get_attachment(inbox_id: int, message_id: int, attachment_id: int) -> Attachment:
+    return attachments_api.get(
+        inbox_id=inbox_id,
+        message_id=message_id,
+        attachment_id=attachment_id,
+    )
+
+
+if __name__ == "__main__":
+    attachments = list_attachments(inbox_id=INBOX_ID, message_id=MESSAGE_ID)
+    print(attachments)

--- a/examples/testing/inboxes.py
+++ b/examples/testing/inboxes.py
@@ -3,8 +3,8 @@ from typing import Optional
 import mailtrap as mt
 from mailtrap.models.inboxes import Inbox
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
 inboxes_api = client.testing_api.inboxes

--- a/examples/testing/messages.py
+++ b/examples/testing/messages.py
@@ -6,8 +6,8 @@ from mailtrap.models.messages import EmailMessage
 from mailtrap.models.messages import ForwardedMessage
 from mailtrap.models.messages import SpamReport
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 INBOX_ID = "YOUR_INBOX_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)

--- a/examples/testing/messages.py
+++ b/examples/testing/messages.py
@@ -53,24 +53,24 @@ def get_html_analysis(inbox_id: int, message_id: str) -> AnalysisReport:
     return messages_api.get_html_analysis(inbox_id=inbox_id, message_id=message_id)
 
 
-def get_text_body(inbox_id: int, message_id: str) -> str:
-    return messages_api.get_text_body(inbox_id=inbox_id, message_id=message_id)
+def get_text_message(inbox_id: int, message_id: str) -> str:
+    return messages_api.get_text_message(inbox_id=inbox_id, message_id=message_id)
 
 
-def get_raw_body(inbox_id: int, message_id: str) -> str:
-    return messages_api.get_raw_body(inbox_id=inbox_id, message_id=message_id)
+def get_raw_message(inbox_id: int, message_id: str) -> str:
+    return messages_api.get_raw_message(inbox_id=inbox_id, message_id=message_id)
 
 
 def get_html_source(inbox_id: int, message_id: str) -> str:
     return messages_api.get_html_source(inbox_id=inbox_id, message_id=message_id)
 
 
-def get_html_body(inbox_id: int, message_id: str) -> str:
-    return messages_api.get_html_body(inbox_id=inbox_id, message_id=message_id)
+def get_html_message(inbox_id: int, message_id: str) -> str:
+    return messages_api.get_html_message(inbox_id=inbox_id, message_id=message_id)
 
 
-def get_eml_body(inbox_id: int, message_id: str) -> str:
-    return messages_api.get_eml_body(inbox_id=inbox_id, message_id=message_id)
+def get_message_as_eml(inbox_id: int, message_id: str) -> str:
+    return messages_api.get_message_as_eml(inbox_id=inbox_id, message_id=message_id)
 
 
 def get_mail_headers(inbox_id: int, message_id: str) -> str:

--- a/examples/testing/projects.py
+++ b/examples/testing/projects.py
@@ -1,8 +1,8 @@
 import mailtrap as mt
 from mailtrap.models.projects import Project
 
-API_TOKEN = "YOU_API_TOKEN"
-ACCOUNT_ID = "YOU_ACCOUNT_ID"
+API_TOKEN = "YOUR_API_TOKEN"
+ACCOUNT_ID = "YOUR_ACCOUNT_ID"
 
 client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
 projects_api = client.testing_api.projects

--- a/mailtrap/api/resources/attachments.py
+++ b/mailtrap/api/resources/attachments.py
@@ -1,0 +1,45 @@
+from typing import Optional
+
+from mailtrap.http import HttpClient
+from mailtrap.models.attachments import Attachment
+
+
+class AttachmentsApi:
+    def __init__(self, client: HttpClient, account_id: str) -> None:
+        self._account_id = account_id
+        self._client = client
+
+    def get_list(
+        self,
+        inbox_id: int,
+        message_id: int,
+    ) -> list[Attachment]:
+        """Lists attachments with their details and download paths."""
+        response = self._client.get(self._api_path(inbox_id, message_id))
+        return [Attachment(**attachment) for attachment in response]
+
+    def get(
+        self,
+        inbox_id: int,
+        message_id: int,
+        attachment_id: int,
+    ) -> Attachment:
+        """Get message single attachment by inbox_id, message_id and attachment_id."""
+        response = self._client.get(self._api_path(inbox_id, message_id, attachment_id))
+        return Attachment(**response)
+
+    def _api_path(
+        self,
+        inbox_id: int,
+        message_id: int,
+        attachment_id: Optional[int] = None,
+    ) -> str:
+        path = (
+            f"/api/accounts/{self._account_id}"
+            f"/inboxes/{inbox_id}"
+            f"/messages/{message_id}"
+            "/attachments"
+        )
+        if attachment_id:
+            return f"{path}/{attachment_id}"
+        return path

--- a/mailtrap/api/resources/messages.py
+++ b/mailtrap/api/resources/messages.py
@@ -107,13 +107,13 @@ class MessagesApi:
         response = self._client.get(f"{self._api_path(inbox_id, message_id)}/analyze")
         return AnalysisReportResponse(**response).report
 
-    def get_text_body(self, inbox_id: int, message_id: int) -> str:
+    def get_text_message(self, inbox_id: int, message_id: int) -> str:
         """Get text email body, if it exists."""
         return cast(
             str, self._client.get(f"{self._api_path(inbox_id, message_id)}/body.txt")
         )
 
-    def get_raw_body(self, inbox_id: int, message_id: int) -> str:
+    def get_raw_message(self, inbox_id: int, message_id: int) -> str:
         """Get raw email body."""
         return cast(
             str, self._client.get(f"{self._api_path(inbox_id, message_id)}/body.raw")
@@ -126,13 +126,13 @@ class MessagesApi:
             self._client.get(f"{self._api_path(inbox_id, message_id)}/body.htmlsource"),
         )
 
-    def get_html_body(self, inbox_id: int, message_id: int) -> str:
+    def get_html_message(self, inbox_id: int, message_id: int) -> str:
         """Get formatted HTML email body. Not applicable for plain text emails."""
         return cast(
             str, self._client.get(f"{self._api_path(inbox_id, message_id)}/body.html")
         )
 
-    def get_eml_body(self, inbox_id: int, message_id: int) -> str:
+    def get_message_as_eml(self, inbox_id: int, message_id: int) -> str:
         """Get email message in .eml format."""
         return cast(
             str, self._client.get(f"{self._api_path(inbox_id, message_id)}/body.eml")

--- a/mailtrap/api/testing.py
+++ b/mailtrap/api/testing.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from mailtrap.api.resources.attachments import AttachmentsApi
 from mailtrap.api.resources.inboxes import InboxesApi
 from mailtrap.api.resources.messages import MessagesApi
 from mailtrap.api.resources.projects import ProjectsApi
@@ -25,3 +26,7 @@ class TestingApi:
     @property
     def messages(self) -> MessagesApi:
         return MessagesApi(account_id=self._account_id, client=self._client)
+
+    @property
+    def attachments(self) -> AttachmentsApi:
+        return AttachmentsApi(account_id=self._account_id, client=self._client)

--- a/mailtrap/models/attachments.py
+++ b/mailtrap/models/attachments.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic.dataclasses import dataclass
+
+from mailtrap.models.mail.attachment import Disposition
+
+
+@dataclass
+class Attachment:
+    id: int
+    message_id: int
+    filename: str
+    attachment_type: Disposition
+    content_type: str
+    attachment_size: int
+    created_at: datetime
+    updated_at: datetime
+    attachment_human_size: str
+    download_path: str
+    content_id: Optional[str] = None
+    transfer_encoding: Optional[str] = None

--- a/tests/unit/api/testing/test_attachments.py
+++ b/tests/unit/api/testing/test_attachments.py
@@ -1,0 +1,159 @@
+from typing import Any
+
+import pytest
+import responses
+
+from mailtrap.api.resources.attachments import AttachmentsApi
+from mailtrap.config import GENERAL_HOST
+from mailtrap.exceptions import APIError
+from mailtrap.http import HttpClient
+from mailtrap.models.attachments import Attachment
+from tests import conftest
+
+ACCOUNT_ID = "321"
+INBOX_ID = 123
+MESSAGE_ID = 457
+ATTACHMENT_ID = 67
+
+BASE_ATTACHMENTS_URL = (
+    f"https://{GENERAL_HOST}/api/accounts/{ACCOUNT_ID}"
+    f"/inboxes/{INBOX_ID}"
+    f"/messages/{MESSAGE_ID}"
+    "/attachments"
+)
+
+
+@pytest.fixture
+def client() -> AttachmentsApi:
+    return AttachmentsApi(account_id=ACCOUNT_ID, client=HttpClient(GENERAL_HOST))
+
+
+@pytest.fixture
+def sample_attachment_dict() -> dict[str, Any]:
+    return {
+        "id": ATTACHMENT_ID,
+        "message_id": 457,
+        "filename": "test.csv",
+        "attachment_type": "inline",
+        "content_type": "plain/text",
+        "content_id": None,
+        "transfer_encoding": None,
+        "attachment_size": 0,
+        "created_at": "2022-06-02T19:25:54.827Z",
+        "updated_at": "2022-06-02T19:25:54.827Z",
+        "attachment_human_size": "0 Bytes",
+        "download_path": (
+            "/api/accounts/321"
+            "/inboxes/123"
+            "/messages/457"
+            f"/attachments/{ATTACHMENT_ID}/download"
+        ),
+    }
+
+
+class TestProjectsApi:
+    @pytest.mark.parametrize(
+        "status_code,response_json,expected_error_message",
+        [
+            (
+                conftest.UNAUTHORIZED_STATUS_CODE,
+                conftest.UNAUTHORIZED_RESPONSE,
+                conftest.UNAUTHORIZED_ERROR_MESSAGE,
+            ),
+            (
+                conftest.FORBIDDEN_STATUS_CODE,
+                conftest.FORBIDDEN_RESPONSE,
+                conftest.FORBIDDEN_ERROR_MESSAGE,
+            ),
+        ],
+    )
+    @responses.activate
+    def test_get_list_should_raise_api_errors(
+        self,
+        client: AttachmentsApi,
+        status_code: int,
+        response_json: dict,
+        expected_error_message: str,
+    ) -> None:
+        responses.get(
+            BASE_ATTACHMENTS_URL,
+            status=status_code,
+            json=response_json,
+        )
+
+        with pytest.raises(APIError) as exc_info:
+            client.get_list(INBOX_ID, MESSAGE_ID)
+
+        assert expected_error_message in str(exc_info.value)
+
+    @responses.activate
+    def test_get_list_should_return_attachments_list(
+        self, client: AttachmentsApi, sample_attachment_dict: dict
+    ) -> None:
+        responses.get(
+            BASE_ATTACHMENTS_URL,
+            json=[sample_attachment_dict],
+            status=200,
+        )
+
+        attachments = client.get_list(INBOX_ID, MESSAGE_ID)
+
+        assert isinstance(attachments, list)
+        assert all(isinstance(a, Attachment) for a in attachments)
+        assert attachments[0].id == ATTACHMENT_ID
+
+    @pytest.mark.parametrize(
+        "status_code,response_json,expected_error_message",
+        [
+            (
+                conftest.UNAUTHORIZED_STATUS_CODE,
+                conftest.UNAUTHORIZED_RESPONSE,
+                conftest.UNAUTHORIZED_ERROR_MESSAGE,
+            ),
+            (
+                conftest.FORBIDDEN_STATUS_CODE,
+                conftest.FORBIDDEN_RESPONSE,
+                conftest.FORBIDDEN_ERROR_MESSAGE,
+            ),
+            (
+                conftest.NOT_FOUND_STATUS_CODE,
+                conftest.NOT_FOUND_RESPONSE,
+                conftest.NOT_FOUND_ERROR_MESSAGE,
+            ),
+        ],
+    )
+    @responses.activate
+    def test_get_should_raise_api_errors(
+        self,
+        client: AttachmentsApi,
+        status_code: int,
+        response_json: dict,
+        expected_error_message: str,
+    ) -> None:
+        url = f"{BASE_ATTACHMENTS_URL}/{ATTACHMENT_ID}"
+        responses.get(
+            url,
+            status=status_code,
+            json=response_json,
+        )
+
+        with pytest.raises(APIError) as exc_info:
+            client.get(INBOX_ID, MESSAGE_ID, ATTACHMENT_ID)
+
+        assert expected_error_message in str(exc_info.value)
+
+    @responses.activate
+    def test_get_should_return_single_attachment(
+        self, client: AttachmentsApi, sample_attachment_dict: dict
+    ) -> None:
+        url = f"{BASE_ATTACHMENTS_URL}/{ATTACHMENT_ID}"
+        responses.get(
+            url,
+            json=sample_attachment_dict,
+            status=200,
+        )
+
+        attachment = client.get(INBOX_ID, MESSAGE_ID, ATTACHMENT_ID)
+
+        assert isinstance(attachment, Attachment)
+        assert attachment.id == ATTACHMENT_ID

--- a/tests/unit/api/testing/test_messages.py
+++ b/tests/unit/api/testing/test_messages.py
@@ -571,7 +571,7 @@ class TestMessagesApi:
         ],
     )
     @responses.activate
-    def test_get_text_body_should_raise_api_errors(
+    def test_get_text_message_should_raise_api_errors(
         self,
         client: MessagesApi,
         status_code: int,
@@ -588,12 +588,14 @@ class TestMessagesApi:
         )
 
         with pytest.raises(APIError) as exc_info:
-            client.get_text_body(INBOX_ID, MESSAGE_ID)
+            client.get_text_message(INBOX_ID, MESSAGE_ID)
 
         assert expected_error_message in str(exc_info.value)
 
     @responses.activate
-    def test_get_text_body_should_return_text_content(self, client: MessagesApi) -> None:
+    def test_get_text_message_should_return_text_content(
+        self, client: MessagesApi
+    ) -> None:
         url = f"{BASE_MESSAGES_URL}/{MESSAGE_ID}/body.txt"
         text_content = "Congrats for sending test email with Mailtrap!"
         responses.get(
@@ -603,7 +605,7 @@ class TestMessagesApi:
             content_type="text/plain",
         )
 
-        result = client.get_text_body(INBOX_ID, MESSAGE_ID)
+        result = client.get_text_message(INBOX_ID, MESSAGE_ID)
 
         assert result == text_content
 
@@ -631,7 +633,7 @@ class TestMessagesApi:
         ],
     )
     @responses.activate
-    def test_get_html_body_should_raise_api_errors(
+    def test_get_html_message_should_raise_api_errors(
         self,
         client: MessagesApi,
         status_code: int,
@@ -648,12 +650,14 @@ class TestMessagesApi:
         )
 
         with pytest.raises(APIError) as exc_info:
-            client.get_html_body(INBOX_ID, MESSAGE_ID)
+            client.get_html_message(INBOX_ID, MESSAGE_ID)
 
         assert expected_error_message in str(exc_info.value)
 
     @responses.activate
-    def test_get_html_body_should_return_html_content(self, client: MessagesApi) -> None:
+    def test_get_html_message_should_return_html_content(
+        self, client: MessagesApi
+    ) -> None:
         url = f"{BASE_MESSAGES_URL}/{MESSAGE_ID}/body.html"
         html_content = "<html><body>Test HTML content</body></html>"
         responses.get(
@@ -663,7 +667,7 @@ class TestMessagesApi:
             content_type="text/html",
         )
 
-        result = client.get_html_body(INBOX_ID, MESSAGE_ID)
+        result = client.get_html_message(INBOX_ID, MESSAGE_ID)
 
         assert result == html_content
 
@@ -691,7 +695,7 @@ class TestMessagesApi:
         ],
     )
     @responses.activate
-    def test_get_raw_body_should_raise_api_errors(
+    def test_get_raw_message_should_raise_api_errors(
         self,
         client: MessagesApi,
         status_code: int,
@@ -708,12 +712,12 @@ class TestMessagesApi:
         )
 
         with pytest.raises(APIError) as exc_info:
-            client.get_raw_body(INBOX_ID, MESSAGE_ID)
+            client.get_raw_message(INBOX_ID, MESSAGE_ID)
 
         assert expected_error_message in str(exc_info.value)
 
     @responses.activate
-    def test_get_raw_body_should_return_raw_content(self, client: MessagesApi) -> None:
+    def test_get_raw_message_should_return_raw_content(self, client: MessagesApi) -> None:
         url = f"{BASE_MESSAGES_URL}/{MESSAGE_ID}/body.raw"
         raw_content = (
             "From: test@example.com\nTo: recipient@example.com\n"
@@ -726,7 +730,7 @@ class TestMessagesApi:
             content_type="text/plain",
         )
 
-        result = client.get_raw_body(INBOX_ID, MESSAGE_ID)
+        result = client.get_raw_message(INBOX_ID, MESSAGE_ID)
 
         assert result == raw_content
 
@@ -814,7 +818,7 @@ class TestMessagesApi:
         ],
     )
     @responses.activate
-    def test_get_eml_body_should_raise_api_errors(
+    def test_get_message_as_eml_should_raise_api_errors(
         self,
         client: MessagesApi,
         status_code: int,
@@ -831,12 +835,14 @@ class TestMessagesApi:
         )
 
         with pytest.raises(APIError) as exc_info:
-            client.get_eml_body(INBOX_ID, MESSAGE_ID)
+            client.get_message_as_eml(INBOX_ID, MESSAGE_ID)
 
         assert expected_error_message in str(exc_info.value)
 
     @responses.activate
-    def test_get_eml_body_should_return_eml_content(self, client: MessagesApi) -> None:
+    def test_get_message_as_eml_should_return_eml_content(
+        self, client: MessagesApi
+    ) -> None:
         url = f"{BASE_MESSAGES_URL}/{MESSAGE_ID}/body.eml"
         eml_content = (
             "From: test@example.com\nTo: recipient@example.com\n"
@@ -849,7 +855,7 @@ class TestMessagesApi:
             content_type="message/rfc822",
         )
 
-        result = client.get_eml_body(INBOX_ID, MESSAGE_ID)
+        result = client.get_message_as_eml(INBOX_ID, MESSAGE_ID)
 
         assert result == eml_content
 


### PR DESCRIPTION
## Motivation
In this PR I added AttachmentsApi, related models, tests, examples

## Changes
- Added AttachmentsApi, models, test, examples
- Rename some resource methods of MessagesApi to follow other SDKs and resource names in documentation
- Fix typo in examples

## How to test
- see examples/testing/attachments.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added attachments support in the Testing API, enabling listing and fetching individual attachments.

- Refactor
  - Renamed message body methods for consistency (breaking change): get_text_body → get_text_message, get_raw_body → get_raw_message, get_html_body → get_html_message, get_eml_body → get_message_as_eml.

- Documentation
  - Added a new attachments example.
  - Updated example placeholders (API token, account ID, template UUID) to clearer “YOUR_…” formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->