### PR TITLE
Add draft-release workflow placeholder

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,27 @@
+# Placeholder draft-release workflow
+#
+name: Draft python Release
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: "Semver bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+
+jobs:
+  draft-release:
+    name: Draft python Release (placeholder)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo inputs
+        env:
+          BUMP_TYPE: ${{ inputs.bump_type }}
+        run: |
+          echo "Placeholder draft-release workflow"
+          echo "bump_type=$BUMP_TYPE"


### PR DESCRIPTION
## Motivation

A `workflow_dispatch` workflow can only be listed and triggered once its file exists on the default branch. Merging this no-op placeholder first puts `draft-release.yml` on `main` so the workflow can be dispatched during implementation.

## Changes

- Add `.github/workflows/draft-release.yml` — `workflow_dispatch` with a `bump_type` (patch/minor/major) choice input; a single job that echoes the input and exits 0.

## How to test

- [ ] Merge this PR — `workflow_dispatch` only appears once the workflow is on the default branch.
- [ ] Actions tab → **Draft python Release** → **Run workflow** → confirm it completes green and logs the selected `bump_type`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manual release workflow to streamline creating draft Python releases with a chosen version bump type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->