### PR TITLE
MT-22678: Add search filter to contact lists get_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The same situation applies to both `client.batch_send()` and `client.sending_api
 
 ### Contacts API:
 - Contacts management – [`contacts/contacts.py`](examples/contacts/contacts.py)
-- Contact Lists management – [`contacts/contact_lists.py`](examples/contacts/contact_lists.py)
+- Contact Lists management (list with optional `search` name filter) – [`contacts/contact_lists.py`](examples/contacts/contact_lists.py)
 - Contact Fields management – [`contacts/contact_fields.py`](examples/contacts/contact_fields.py)
 - Contact Events – [`contacts/contact_events.py`](examples/contacts/contact_events.py)
 - Contact Exports – [`contacts/contact_exports.py`](examples/contacts/contact_exports.py)

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The same situation applies to both `client.batch_send()` and `client.sending_api
 
 ### Contacts API:
 - Contacts management – [`contacts/contacts.py`](examples/contacts/contacts.py)
-- Contact Lists management (list with optional `search` name filter) – [`contacts/contact_lists.py`](examples/contacts/contact_lists.py)
+- Contact Lists management – [`contacts/contact_lists.py`](examples/contacts/contact_lists.py)
 - Contact Fields management – [`contacts/contact_fields.py`](examples/contacts/contact_fields.py)
 - Contact Events – [`contacts/contact_events.py`](examples/contacts/contact_events.py)
 - Contact Exports – [`contacts/contact_exports.py`](examples/contacts/contact_exports.py)

--- a/examples/contacts/contact_lists.py
+++ b/examples/contacts/contact_lists.py
@@ -23,6 +23,11 @@ def list_contact_lists() -> list[ContactList]:
     return contact_lists_api.get_list()
 
 
+def search_contact_lists(search: str) -> list[ContactList]:
+    # Filter lists by name (case-insensitive prefix match).
+    return contact_lists_api.get_list(search=search)
+
+
 def get_contact_list(contact_list_id: int) -> ContactList:
     return contact_lists_api.get_by_id(contact_list_id)
 
@@ -37,6 +42,9 @@ if __name__ == "__main__":
 
     lists = list_contact_lists()
     print(lists)
+
+    matching_lists = search_contact_lists(search="news")
+    print(matching_lists)
 
     contact_list = get_contact_list(contact_list_id=created.id)
     print(contact_list)

--- a/mailtrap/api/resources/contact_lists.py
+++ b/mailtrap/api/resources/contact_lists.py
@@ -4,6 +4,7 @@ from mailtrap.http import HttpClient
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.contacts import ContactList
 from mailtrap.models.contacts import ContactListParams
+from mailtrap.models.contacts import ContactListsFilterParams
 
 
 class ContactListsApi:
@@ -11,9 +12,15 @@ class ContactListsApi:
         self._account_id = account_id
         self._client = client
 
-    def get_list(self) -> list[ContactList]:
-        """Get all contact lists existing in your account."""
-        response = self._client.get(self._api_path())
+    def get_list(self, search: Optional[str] = None) -> list[ContactList]:
+        """
+        Get all contact lists existing in your account.
+
+        :param search: Optionally filter lists by name
+            (case-insensitive prefix match).
+        """
+        params = ContactListsFilterParams(search=search)
+        response = self._client.get(self._api_path(), params=params.api_query_params)
         return [ContactList(**field) for field in response]
 
     def get_by_id(self, list_id: int) -> ContactList:

--- a/mailtrap/models/contacts.py
+++ b/mailtrap/models/contacts.py
@@ -39,6 +39,12 @@ class ContactListParams(RequestParams):
 
 
 @dataclass
+class ContactListsFilterParams(RequestParams):
+    # Filter contact lists by name (case-insensitive prefix match).
+    search: Optional[str] = None
+
+
+@dataclass
 class ContactList:
     id: int
     name: str

--- a/tests/unit/api/contacts/test_contact_lists.py
+++ b/tests/unit/api/contacts/test_contact_lists.py
@@ -106,6 +106,24 @@ class TestContactListsApi:
         )
         assert contact_lists[0].id == LIST_ID
 
+    @responses.activate
+    def test_get_contact_lists_with_search_should_filter_by_name(
+        self, contact_lists_api: ContactListsApi, sample_contact_list_dict: dict
+    ) -> None:
+        search = "news"
+        responses.get(
+            BASE_CONTACT_LISTS_URL,
+            json=[sample_contact_list_dict],
+            status=200,
+            match=[responses.matchers.query_param_matcher({"search": search})],
+        )
+
+        contact_lists = contact_lists_api.get_list(search=search)
+
+        assert isinstance(contact_lists, list)
+        assert contact_lists[0].id == LIST_ID
+        assert responses.calls[0].request.params["search"] == search
+
     @pytest.mark.parametrize(
         "status_code,response_json,expected_error_message",
         [


### PR DESCRIPTION
## Motivation

https://railsware.atlassian.net/browse/MT-22678

## Changes

- Add an optional `search` argument to `contact_lists.get_list` — filters contact lists by name (case-insensitive prefix match), per the OpenAPI `GET /api/contacts/lists` param. Sent only when provided, so the default call is unchanged.

## How to test

- [ ] `client.contact_lists.get_list()` — returns all contact lists (unchanged behaviour).
- [ ] `client.contact_lists.get_list(search="news")` — returns only lists whose name starts with "news" (case-insensitive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional name-based search when retrieving contact lists.
  * Search supports case-insensitive prefix matching.
  * Added an example demonstrating how to search and display matching lists.

* **Documentation**
  * Updated the Contacts API documentation to describe the optional search filter.

* **Tests**
  * Added coverage verifying search parameters and filtered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->