### PR TITLE
Add Inbound Email API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,12 @@ The same situation applies to both `client.batch_send()` and `client.sending_api
 ### Sending Domains API:
 - Sending Domains – [`sending_domains/sending_domains.py`](examples/sending_domains/sending_domains.py)
 
+### Inbound Email API:
+- Folders management – [`inbound/folders.py`](examples/inbound/folders.py)
+- Inboxes management – [`inbound/inboxes.py`](examples/inbound/inboxes.py)
+- Messages (list/get/delete + reply/reply_all/forward) – [`inbound/messages.py`](examples/inbound/messages.py)
+- Threads (list/get/delete) – [`inbound/threads.py`](examples/inbound/threads.py)
+
 ### Webhooks API:
 - Webhooks management – [`webhooks/webhooks.py`](examples/webhooks/webhooks.py)
 - Verifying webhook signatures – [`webhooks/verify_signature.py`](examples/webhooks/verify_signature.py)

--- a/examples/contacts/contact_events.py
+++ b/examples/contacts/contact_events.py
@@ -1,10 +1,12 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.contacts import ContactEvent
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 contact_events_api = client.contacts_api.contact_events
 
 

--- a/examples/contacts/contact_exports.py
+++ b/examples/contacts/contact_exports.py
@@ -1,10 +1,12 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.contacts import ContactExportDetail
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 contact_exports_api = client.contacts_api.contact_exports
 
 

--- a/examples/contacts/contact_fields.py
+++ b/examples/contacts/contact_fields.py
@@ -1,13 +1,14 @@
+import os
 from typing import Optional
 
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.contacts import ContactField
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 contact_fields_api = client.contacts_api.contact_fields
 
 

--- a/examples/contacts/contact_imports.py
+++ b/examples/contacts/contact_imports.py
@@ -1,10 +1,12 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.contacts import ContactImport
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 contact_imports_api = client.contacts_api.contact_imports
 
 

--- a/examples/contacts/contact_lists.py
+++ b/examples/contacts/contact_lists.py
@@ -1,11 +1,13 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.contacts import ContactList
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 contact_lists_api = client.contacts_api.contact_lists
 
 

--- a/examples/contacts/contacts.py
+++ b/examples/contacts/contacts.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 from typing import Union
 
@@ -5,10 +6,10 @@ import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.contacts import Contact
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 contacts_api = client.contacts_api.contacts
 
 

--- a/examples/email_logs/email_logs.py
+++ b/examples/email_logs/email_logs.py
@@ -1,3 +1,5 @@
+import os
+
 """Example: List email logs and get a single message by ID."""
 
 from datetime import datetime
@@ -10,10 +12,10 @@ from mailtrap.models.email_logs import filter_ci_equal
 from mailtrap.models.email_logs import filter_string_equal
 from mailtrap.models.email_logs import filter_string_not_empty
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 email_logs_api = client.email_logs_api.email_logs
 
 

--- a/examples/email_templates/templates.py
+++ b/examples/email_templates/templates.py
@@ -1,13 +1,14 @@
+import os
 from typing import Optional
 
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.templates import EmailTemplate
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 templates_api = client.email_templates_api.templates
 
 

--- a/examples/general/account_accesses.py
+++ b/examples/general/account_accesses.py
@@ -1,11 +1,13 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.accounts import AccountAccess
 from mailtrap.models.common import DeletedObject
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 account_accesses_api = client.general_api.account_accesses
 
 

--- a/examples/general/accounts.py
+++ b/examples/general/accounts.py
@@ -1,9 +1,11 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.accounts import Account
 
-API_TOKEN = "YOUR_API_TOKEN"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 accounts_api = client.general_api.accounts
 
 

--- a/examples/general/api_tokens.py
+++ b/examples/general/api_tokens.py
@@ -1,12 +1,14 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.api_tokens import ApiToken
 from mailtrap.models.api_tokens import ApiTokenWithToken
 from mailtrap.models.common import DeletedObject
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 api_tokens_api = client.general_api.api_tokens
 
 

--- a/examples/general/billing.py
+++ b/examples/general/billing.py
@@ -1,10 +1,12 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.billing import BillingCycleUsage
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 billing_api = client.general_api.billing
 
 

--- a/examples/general/permissions.py
+++ b/examples/general/permissions.py
@@ -1,11 +1,13 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.permissions import PermissionResource
 from mailtrap.models.permissions import UpdatePermissionsResponse
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 permissions_api = client.general_api.permissions
 
 

--- a/examples/inbound/folders.py
+++ b/examples/inbound/folders.py
@@ -1,10 +1,12 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.inbound import InboundFolder
 
-API_TOKEN = "YOUR_API_TOKEN"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 folders_api = client.inbound_api.folders
 
 

--- a/examples/inbound/folders.py
+++ b/examples/inbound/folders.py
@@ -1,0 +1,38 @@
+import mailtrap as mt
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import InboundFolder
+
+API_TOKEN = "YOUR_API_TOKEN"
+
+client = mt.MailtrapClient(token=API_TOKEN)
+folders_api = client.inbound_api.folders
+
+
+def list_folders() -> list[InboundFolder]:
+    return folders_api.get_list()
+
+
+def get_folder(folder_id: int) -> InboundFolder:
+    return folders_api.get_by_id(folder_id)
+
+
+def create_folder(name: str) -> InboundFolder:
+    return folders_api.create(mt.CreateInboundFolderParams(name=name))
+
+
+def update_folder(folder_id: int, name: str) -> InboundFolder:
+    return folders_api.update(folder_id, mt.UpdateInboundFolderParams(name=name))
+
+
+def delete_folder(folder_id: int) -> DeletedObject:
+    return folders_api.delete(folder_id)
+
+
+if __name__ == "__main__":
+    folder = create_folder("Support")
+    print(folder)
+
+    print(list_folders())
+    print(get_folder(folder.id))
+    print(update_folder(folder.id, "Support (renamed)"))
+    print(delete_folder(folder.id))

--- a/examples/inbound/inboxes.py
+++ b/examples/inbound/inboxes.py
@@ -1,11 +1,13 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.inbound import InboundInbox
 
-API_TOKEN = "YOUR_API_TOKEN"
-FOLDER_ID = 42
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+FOLDER_ID = int(os.environ["MAILTRAP_INBOUND_FOLDER_ID"])
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 inboxes_api = client.inbound_api.inboxes
 
 

--- a/examples/inbound/inboxes.py
+++ b/examples/inbound/inboxes.py
@@ -1,0 +1,40 @@
+import mailtrap as mt
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import InboundInbox
+
+API_TOKEN = "YOUR_API_TOKEN"
+FOLDER_ID = 42
+
+client = mt.MailtrapClient(token=API_TOKEN)
+inboxes_api = client.inbound_api.inboxes
+
+
+def list_inboxes(folder_id: int) -> list[InboundInbox]:
+    return inboxes_api.get_list(folder_id)
+
+
+def get_inbox(folder_id: int, inbox_id: int) -> InboundInbox:
+    return inboxes_api.get_by_id(folder_id, inbox_id)
+
+
+def create_inbox(folder_id: int, name: str) -> InboundInbox:
+    # Omit domain_id for a Mailtrap-hosted inbox; pass it for a custom-domain inbox.
+    return inboxes_api.create(folder_id, mt.CreateInboundInboxParams(name=name))
+
+
+def update_inbox(folder_id: int, inbox_id: int, name: str) -> InboundInbox:
+    return inboxes_api.update(folder_id, inbox_id, mt.UpdateInboundInboxParams(name=name))
+
+
+def delete_inbox(folder_id: int, inbox_id: int) -> DeletedObject:
+    return inboxes_api.delete(folder_id, inbox_id)
+
+
+if __name__ == "__main__":
+    inbox = create_inbox(FOLDER_ID, "Tickets")
+    print(inbox)
+
+    print(list_inboxes(FOLDER_ID))
+    print(get_inbox(FOLDER_ID, inbox.id))
+    print(update_inbox(FOLDER_ID, inbox.id, "Tickets (renamed)"))
+    print(delete_inbox(FOLDER_ID, inbox.id))

--- a/examples/inbound/messages.py
+++ b/examples/inbound/messages.py
@@ -1,0 +1,53 @@
+import mailtrap as mt
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import InboundMessageDetails
+from mailtrap.models.inbound import InboundMessagesListResponse
+from mailtrap.models.inbound import InboundSendResult
+from mailtrap.models.mail.address import Address
+
+API_TOKEN = "YOUR_API_TOKEN"
+INBOX_ID = 9
+
+client = mt.MailtrapClient(token=API_TOKEN)
+messages_api = client.inbound_api.messages
+
+
+def list_messages(inbox_id: int) -> InboundMessagesListResponse:
+    # Pass last_id from the previous page to paginate.
+    return messages_api.get_list(inbox_id)
+
+
+def get_message(inbox_id: int, message_id: str) -> InboundMessageDetails:
+    return messages_api.get_by_id(inbox_id, message_id)
+
+
+def delete_message(inbox_id: int, message_id: str) -> DeletedObject:
+    return messages_api.delete(inbox_id, message_id)
+
+
+def reply(inbox_id: int, message_id: str, text: str) -> InboundSendResult:
+    params = mt.ReplyInboundMessageParams(text=text)
+    return messages_api.reply(inbox_id, message_id, params)
+
+
+def reply_all(inbox_id: int, message_id: str, text: str) -> InboundSendResult:
+    params = mt.ReplyInboundMessageParams(text=text)
+    return messages_api.reply_all(inbox_id, message_id, params)
+
+
+def forward(inbox_id: int, message_id: str, to: str) -> InboundSendResult:
+    params = mt.ForwardInboundMessageParams(to=[Address(email=to)])
+    return messages_api.forward(inbox_id, message_id, params)
+
+
+if __name__ == "__main__":
+    page = list_messages(INBOX_ID)
+    print(f"{len(page.data)} of {page.total_count} messages")
+
+    if page.data:
+        message_id = page.data[0].id
+        print(get_message(INBOX_ID, message_id))
+        print(reply(INBOX_ID, message_id, "Thanks for reaching out!"))
+        print(reply_all(INBOX_ID, message_id, "Looping everyone in."))
+        print(forward(INBOX_ID, message_id, "colleague@example.com"))
+        print(delete_message(INBOX_ID, message_id))

--- a/examples/inbound/messages.py
+++ b/examples/inbound/messages.py
@@ -1,3 +1,5 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.inbound import InboundMessageDetails
@@ -5,10 +7,10 @@ from mailtrap.models.inbound import InboundMessagesListResponse
 from mailtrap.models.inbound import InboundSendResult
 from mailtrap.models.mail.address import Address
 
-API_TOKEN = "YOUR_API_TOKEN"
-INBOX_ID = 9
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+INBOX_ID = int(os.environ["MAILTRAP_INBOUND_INBOX_ID"])
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 messages_api = client.inbound_api.messages
 
 

--- a/examples/inbound/threads.py
+++ b/examples/inbound/threads.py
@@ -1,12 +1,14 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.inbound import InboundThread
 from mailtrap.models.inbound import InboundThreadsListResponse
 
-API_TOKEN = "YOUR_API_TOKEN"
-INBOX_ID = 9
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+INBOX_ID = int(os.environ["MAILTRAP_INBOUND_INBOX_ID"])
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 threads_api = client.inbound_api.threads
 
 

--- a/examples/inbound/threads.py
+++ b/examples/inbound/threads.py
@@ -1,0 +1,33 @@
+import mailtrap as mt
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import InboundThread
+from mailtrap.models.inbound import InboundThreadsListResponse
+
+API_TOKEN = "YOUR_API_TOKEN"
+INBOX_ID = 9
+
+client = mt.MailtrapClient(token=API_TOKEN)
+threads_api = client.inbound_api.threads
+
+
+def list_threads(inbox_id: int) -> InboundThreadsListResponse:
+    # Pass last_id from the previous page to paginate.
+    return threads_api.get_list(inbox_id)
+
+
+def get_thread(inbox_id: int, thread_id: str) -> InboundThread:
+    return threads_api.get_by_id(inbox_id, thread_id)
+
+
+def delete_thread(inbox_id: int, thread_id: str) -> DeletedObject:
+    return threads_api.delete(inbox_id, thread_id)
+
+
+if __name__ == "__main__":
+    page = list_threads(INBOX_ID)
+    print(f"{len(page.data)} of {page.total_count} threads")
+
+    if page.data:
+        thread_id = page.data[0].id
+        print(get_thread(INBOX_ID, thread_id))
+        print(delete_thread(INBOX_ID, thread_id))

--- a/examples/organizations/sub_accounts.py
+++ b/examples/organizations/sub_accounts.py
@@ -1,10 +1,12 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.organizations import SubAccount
 
-API_TOKEN = "YOUR_API_TOKEN"
-ORGANIZATION_ID = "YOUR_ORGANIZATION_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ORGANIZATION_ID = os.environ["MAILTRAP_ORGANIZATION_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, organization_id=ORGANIZATION_ID)
+client = mt.MailtrapClient(token=API_KEY, organization_id=ORGANIZATION_ID)
 sub_accounts_api = client.organizations_api.sub_accounts
 
 

--- a/examples/sending/advanced_sending.py
+++ b/examples/sending/advanced_sending.py
@@ -1,9 +1,10 @@
 import base64
+import os
 from pathlib import Path
 
 import mailtrap as mt
 
-API_TOKEN = "<YOUR_API_TOKEN>"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
 
 
 class SendingType:
@@ -14,14 +15,14 @@ class SendingType:
 
 def get_client(type_: SendingType) -> mt.MailtrapClient:
     if type_ == SendingType.DEFAULT:
-        return mt.MailtrapClient(token=API_TOKEN)
+        return mt.MailtrapClient(token=API_KEY)
     elif type_ == SendingType.BULK:
-        return mt.MailtrapClient(token=API_TOKEN, bulk=True)
+        return mt.MailtrapClient(token=API_KEY, bulk=True)
     elif type_ == SendingType.SANDBOX:
         return mt.MailtrapClient(
-            token=API_TOKEN,
+            token=API_KEY,
             sandbox=True,
-            inbox_id="<YOUR_INBOX_ID>",
+            inbox_id=os.environ["MAILTRAP_INBOX_ID"],
         )
     raise ValueError(f"Invalid sending type: {type_}")
 

--- a/examples/sending/batch_advanced_sending.py
+++ b/examples/sending/batch_advanced_sending.py
@@ -1,9 +1,10 @@
 import base64
+import os
 from pathlib import Path
 
 import mailtrap as mt
 
-API_TOKEN = "<YOUR_API_TOKEN>"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
 
 
 class SendingType:
@@ -14,14 +15,14 @@ class SendingType:
 
 def get_client(type_: SendingType) -> mt.MailtrapClient:
     if type_ == SendingType.DEFAULT:
-        return mt.MailtrapClient(token=API_TOKEN)
+        return mt.MailtrapClient(token=API_KEY)
     elif type_ == SendingType.BULK:
-        return mt.MailtrapClient(token=API_TOKEN, bulk=True)
+        return mt.MailtrapClient(token=API_KEY, bulk=True)
     elif type_ == SendingType.SANDBOX:
         return mt.MailtrapClient(
-            token=API_TOKEN,
+            token=API_KEY,
             sandbox=True,
-            inbox_id="<YOUR_INBOX_ID>",
+            inbox_id=os.environ["MAILTRAP_INBOX_ID"],
         )
     raise ValueError(f"Invalid sending type: {type_}")
 

--- a/examples/sending/batch_minimal_sending.py
+++ b/examples/sending/batch_minimal_sending.py
@@ -1,7 +1,9 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.mail.batch_mail import BatchSendResponse
 
-API_TOKEN = "<YOUR_API_TOKEN>"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
 
 
 class SendingType:
@@ -12,12 +14,12 @@ class SendingType:
 
 def get_client(type_: SendingType) -> mt.MailtrapClient:
     if type_ == SendingType.DEFAULT:
-        return mt.MailtrapClient(token=API_TOKEN)
+        return mt.MailtrapClient(token=API_KEY)
     elif type_ == SendingType.BULK:
-        return mt.MailtrapClient(token=API_TOKEN, bulk=True)
+        return mt.MailtrapClient(token=API_KEY, bulk=True)
     elif type_ == SendingType.SANDBOX:
         return mt.MailtrapClient(
-            token=API_TOKEN, sandbox=True, inbox_id="<YOUR_INBOX_ID>"
+            token=API_KEY, sandbox=True, inbox_id=os.environ["MAILTRAP_INBOX_ID"]
         )
     raise ValueError(f"Invalid sending type: {type_}")
 

--- a/examples/sending/batch_sending_with_template.py
+++ b/examples/sending/batch_sending_with_template.py
@@ -1,6 +1,8 @@
+import os
+
 import mailtrap as mt
 
-API_TOKEN = "<YOUR_API_TOKEN>"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
 
 
 class SendingType:
@@ -11,12 +13,12 @@ class SendingType:
 
 def get_client(type_: SendingType) -> mt.MailtrapClient:
     if type_ == SendingType.DEFAULT:
-        return mt.MailtrapClient(token=API_TOKEN)
+        return mt.MailtrapClient(token=API_KEY)
     elif type_ == SendingType.BULK:
-        return mt.MailtrapClient(token=API_TOKEN, bulk=True)
+        return mt.MailtrapClient(token=API_KEY, bulk=True)
     elif type_ == SendingType.SANDBOX:
         return mt.MailtrapClient(
-            token=API_TOKEN, sandbox=True, inbox_id="<YOUR_INBOX_ID>"
+            token=API_KEY, sandbox=True, inbox_id=os.environ["MAILTRAP_INBOX_ID"]
         )
     raise ValueError(f"Invalid sending type: {type_}")
 

--- a/examples/sending/minimal_sending.py
+++ b/examples/sending/minimal_sending.py
@@ -1,7 +1,9 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.mail.mail import SendingMailResponse
 
-API_TOKEN = "<YOUR_API_TOKEN>"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
 
 
 class SendingType:
@@ -12,12 +14,12 @@ class SendingType:
 
 def get_client(type_: SendingType) -> mt.MailtrapClient:
     if type_ == SendingType.DEFAULT:
-        return mt.MailtrapClient(token=API_TOKEN)
+        return mt.MailtrapClient(token=API_KEY)
     elif type_ == SendingType.BULK:
-        return mt.MailtrapClient(token=API_TOKEN, bulk=True)
+        return mt.MailtrapClient(token=API_KEY, bulk=True)
     elif type_ == SendingType.SANDBOX:
         return mt.MailtrapClient(
-            token=API_TOKEN, sandbox=True, inbox_id="<YOUR_INBOX_ID>"
+            token=API_KEY, sandbox=True, inbox_id=os.environ["MAILTRAP_INBOX_ID"]
         )
     raise ValueError(f"Invalid sending type: {type_}")
 

--- a/examples/sending/sending_with_template.py
+++ b/examples/sending/sending_with_template.py
@@ -1,6 +1,8 @@
+import os
+
 import mailtrap as mt
 
-API_TOKEN = "<YOUR_API_TOKEN>"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
 
 
 class SendingType:
@@ -11,12 +13,12 @@ class SendingType:
 
 def get_client(type_: SendingType) -> mt.MailtrapClient:
     if type_ == SendingType.DEFAULT:
-        return mt.MailtrapClient(token=API_TOKEN)
+        return mt.MailtrapClient(token=API_KEY)
     elif type_ == SendingType.BULK:
-        return mt.MailtrapClient(token=API_TOKEN, bulk=True)
+        return mt.MailtrapClient(token=API_KEY, bulk=True)
     elif type_ == SendingType.SANDBOX:
         return mt.MailtrapClient(
-            token=API_TOKEN, sandbox=True, inbox_id="<YOUR_INBOX_ID>"
+            token=API_KEY, sandbox=True, inbox_id=os.environ["MAILTRAP_INBOX_ID"]
         )
     raise ValueError(f"Invalid sending type: {type_}")
 

--- a/examples/sending_domains/sending_domains.py
+++ b/examples/sending_domains/sending_domains.py
@@ -1,12 +1,14 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.sending_domains import SendingDomain
 from mailtrap.models.sending_domains import SendSetupInstructionsResponse
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 sending_domains_api = client.sending_domains_api.sending_domains
 
 

--- a/examples/stats/stats.py
+++ b/examples/stats/stats.py
@@ -1,12 +1,14 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.stats import SendingStatGroup
 from mailtrap.models.stats import SendingStats
 from mailtrap.models.stats import StatsFilterParams
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN)
+client = mt.MailtrapClient(token=API_KEY)
 stats_api = client.stats_api
 
 

--- a/examples/suppressions/suppressions.py
+++ b/examples/suppressions/suppressions.py
@@ -1,12 +1,13 @@
+import os
 from typing import Optional
 
 import mailtrap as mt
 from mailtrap.models.suppressions import Suppression
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 suppressions_api = client.suppressions_api.suppressions
 
 

--- a/examples/testing/attachments.py
+++ b/examples/testing/attachments.py
@@ -1,12 +1,14 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.attachments import Attachment
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
-INBOX_ID = "YOUR_INBOX_ID"
-MESSAGE_ID = "YOUR_MESSAGE_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
+INBOX_ID = os.environ["MAILTRAP_INBOX_ID"]
+MESSAGE_ID = os.environ["MAILTRAP_SANDBOX_MESSAGE_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 attachments_api = client.testing_api.attachments
 
 

--- a/examples/testing/inboxes.py
+++ b/examples/testing/inboxes.py
@@ -1,12 +1,13 @@
+import os
 from typing import Optional
 
 import mailtrap as mt
 from mailtrap.models.inboxes import Inbox
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 inboxes_api = client.testing_api.inboxes
 
 

--- a/examples/testing/messages.py
+++ b/examples/testing/messages.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 import mailtrap as mt
@@ -6,11 +7,11 @@ from mailtrap.models.messages import EmailMessage
 from mailtrap.models.messages import ForwardedMessage
 from mailtrap.models.messages import SpamReport
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
-INBOX_ID = "YOUR_INBOX_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
+INBOX_ID = os.environ["MAILTRAP_INBOX_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 messages_api = client.testing_api.messages
 
 

--- a/examples/testing/projects.py
+++ b/examples/testing/projects.py
@@ -1,10 +1,12 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.projects import Project
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 projects_api = client.testing_api.projects
 
 

--- a/examples/webhooks/webhooks.py
+++ b/examples/webhooks/webhooks.py
@@ -1,12 +1,14 @@
+import os
+
 import mailtrap as mt
 from mailtrap.models.common import DeletedObject
 from mailtrap.models.webhooks import Webhook
 from mailtrap.models.webhooks import WebhookWithSecret
 
-API_TOKEN = "YOUR_API_TOKEN"
-ACCOUNT_ID = "YOUR_ACCOUNT_ID"
+API_KEY = os.environ["MAILTRAP_API_KEY"]
+ACCOUNT_ID = os.environ["MAILTRAP_ACCOUNT_ID"]
 
-client = mt.MailtrapClient(token=API_TOKEN, account_id=ACCOUNT_ID)
+client = mt.MailtrapClient(token=API_KEY, account_id=ACCOUNT_ID)
 webhooks_api = client.webhooks_api.webhooks
 
 

--- a/mailtrap/__init__.py
+++ b/mailtrap/__init__.py
@@ -20,6 +20,12 @@ from .models.contacts import UpdateContactParams
 from .models.email_logs import EmailLogMessage
 from .models.email_logs import EmailLogsListFilters
 from .models.email_logs import EmailLogsListResponse
+from .models.inbound import CreateInboundFolderParams
+from .models.inbound import CreateInboundInboxParams
+from .models.inbound import ForwardInboundMessageParams
+from .models.inbound import ReplyInboundMessageParams
+from .models.inbound import UpdateInboundFolderParams
+from .models.inbound import UpdateInboundInboxParams
 from .models.inboxes import CreateInboxParams
 from .models.inboxes import UpdateInboxParams
 from .models.mail import Address

--- a/mailtrap/api/inbound.py
+++ b/mailtrap/api/inbound.py
@@ -1,0 +1,26 @@
+from mailtrap.api.resources.inbound_folders import InboundFoldersApi
+from mailtrap.api.resources.inbound_inboxes import InboundInboxesApi
+from mailtrap.api.resources.inbound_messages import InboundMessagesApi
+from mailtrap.api.resources.inbound_threads import InboundThreadsApi
+from mailtrap.http import HttpClient
+
+
+class InboundBaseApi:
+    def __init__(self, client: HttpClient) -> None:
+        self._client = client
+
+    @property
+    def folders(self) -> InboundFoldersApi:
+        return InboundFoldersApi(client=self._client)
+
+    @property
+    def inboxes(self) -> InboundInboxesApi:
+        return InboundInboxesApi(client=self._client)
+
+    @property
+    def messages(self) -> InboundMessagesApi:
+        return InboundMessagesApi(client=self._client)
+
+    @property
+    def threads(self) -> InboundThreadsApi:
+        return InboundThreadsApi(client=self._client)

--- a/mailtrap/api/resources/inbound_folders.py
+++ b/mailtrap/api/resources/inbound_folders.py
@@ -1,0 +1,43 @@
+from typing import Optional
+
+from mailtrap.http import HttpClient
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import CreateInboundFolderParams
+from mailtrap.models.inbound import InboundFolder
+from mailtrap.models.inbound import UpdateInboundFolderParams
+
+
+class InboundFoldersApi:
+    def __init__(self, client: HttpClient) -> None:
+        self._client = client
+
+    def get_list(self) -> list[InboundFolder]:
+        """Get all inbound folders in the account."""
+        response = self._client.get(self._api_path())
+        return [InboundFolder(**folder) for folder in response]
+
+    def get_by_id(self, folder_id: int) -> InboundFolder:
+        """Get an inbound folder by ID."""
+        response = self._client.get(self._api_path(folder_id))
+        return InboundFolder(**response)
+
+    def create(self, params: CreateInboundFolderParams) -> InboundFolder:
+        """Create a new inbound folder."""
+        response = self._client.post(self._api_path(), json=params.api_data)
+        return InboundFolder(**response)
+
+    def update(self, folder_id: int, params: UpdateInboundFolderParams) -> InboundFolder:
+        """Rename an inbound folder."""
+        response = self._client.patch(self._api_path(folder_id), json=params.api_data)
+        return InboundFolder(**response)
+
+    def delete(self, folder_id: int) -> DeletedObject:
+        """Delete an inbound folder along with all of its inboxes."""
+        self._client.delete(self._api_path(folder_id))
+        return DeletedObject(folder_id)
+
+    def _api_path(self, folder_id: Optional[int] = None) -> str:
+        path = "/api/inbound/folders"
+        if folder_id:
+            return f"{path}/{folder_id}"
+        return path

--- a/mailtrap/api/resources/inbound_inboxes.py
+++ b/mailtrap/api/resources/inbound_inboxes.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+from mailtrap.http import HttpClient
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import CreateInboundInboxParams
+from mailtrap.models.inbound import InboundInbox
+from mailtrap.models.inbound import UpdateInboundInboxParams
+
+
+class InboundInboxesApi:
+    def __init__(self, client: HttpClient) -> None:
+        self._client = client
+
+    def get_list(self, folder_id: int) -> list[InboundInbox]:
+        """Get all inboxes in an inbound folder."""
+        response = self._client.get(self._api_path(folder_id))
+        return [InboundInbox(**inbox) for inbox in response]
+
+    def get_by_id(self, folder_id: int, inbox_id: int) -> InboundInbox:
+        """Get an inbound inbox by ID."""
+        response = self._client.get(self._api_path(folder_id, inbox_id))
+        return InboundInbox(**response)
+
+    def create(self, folder_id: int, params: CreateInboundInboxParams) -> InboundInbox:
+        """Create a new inbound inbox in a folder."""
+        response = self._client.post(self._api_path(folder_id), json=params.api_data)
+        return InboundInbox(**response)
+
+    def update(
+        self, folder_id: int, inbox_id: int, params: UpdateInboundInboxParams
+    ) -> InboundInbox:
+        """Rename an inbound inbox."""
+        response = self._client.patch(
+            self._api_path(folder_id, inbox_id), json=params.api_data
+        )
+        return InboundInbox(**response)
+
+    def delete(self, folder_id: int, inbox_id: int) -> DeletedObject:
+        """Delete an inbound inbox."""
+        self._client.delete(self._api_path(folder_id, inbox_id))
+        return DeletedObject(inbox_id)
+
+    def _api_path(self, folder_id: int, inbox_id: Optional[int] = None) -> str:
+        path = f"/api/inbound/folders/{folder_id}/inboxes"
+        if inbox_id:
+            return f"{path}/{inbox_id}"
+        return path

--- a/mailtrap/api/resources/inbound_messages.py
+++ b/mailtrap/api/resources/inbound_messages.py
@@ -1,0 +1,71 @@
+from typing import Any
+from typing import Optional
+
+from mailtrap.http import HttpClient
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import ForwardInboundMessageParams
+from mailtrap.models.inbound import InboundMessageDetails
+from mailtrap.models.inbound import InboundMessagesListResponse
+from mailtrap.models.inbound import InboundSendResult
+from mailtrap.models.inbound import ReplyInboundMessageParams
+
+
+class InboundMessagesApi:
+    def __init__(self, client: HttpClient) -> None:
+        self._client = client
+
+    def get_list(
+        self, inbox_id: int, last_id: Optional[str] = None
+    ) -> InboundMessagesListResponse:
+        """
+        List received messages in an inbox. Pass last_id from a previous
+        response to fetch the next page.
+        """
+        params: dict[str, Any] = {}
+        if last_id:
+            params["last_id"] = last_id
+        response = self._client.get(self._api_path(inbox_id), params=params or None)
+        return InboundMessagesListResponse(**response)
+
+    def get_by_id(self, inbox_id: int, message_id: str) -> InboundMessageDetails:
+        """Get a single message with its body and attachment download URLs."""
+        response = self._client.get(self._api_path(inbox_id, message_id))
+        return InboundMessageDetails(**response)
+
+    def delete(self, inbox_id: int, message_id: str) -> DeletedObject:
+        """Delete a message."""
+        self._client.delete(self._api_path(inbox_id, message_id))
+        return DeletedObject(message_id)
+
+    def reply(
+        self, inbox_id: int, message_id: str, params: ReplyInboundMessageParams
+    ) -> InboundSendResult:
+        """Reply to a message (to the original sender). Sends a real email."""
+        response = self._client.post(
+            f"{self._api_path(inbox_id, message_id)}/reply", json=params.api_data
+        )
+        return InboundSendResult(**response)
+
+    def reply_all(
+        self, inbox_id: int, message_id: str, params: ReplyInboundMessageParams
+    ) -> InboundSendResult:
+        """Reply to a message and copy its other recipients. Sends a real email."""
+        response = self._client.post(
+            f"{self._api_path(inbox_id, message_id)}/reply_all", json=params.api_data
+        )
+        return InboundSendResult(**response)
+
+    def forward(
+        self, inbox_id: int, message_id: str, params: ForwardInboundMessageParams
+    ) -> InboundSendResult:
+        """Forward a message to new recipients. Sends a real email."""
+        response = self._client.post(
+            f"{self._api_path(inbox_id, message_id)}/forward", json=params.api_data
+        )
+        return InboundSendResult(**response)
+
+    def _api_path(self, inbox_id: int, message_id: Optional[str] = None) -> str:
+        path = f"/api/inbound/inboxes/{inbox_id}/messages"
+        if message_id:
+            return f"{path}/{message_id}"
+        return path

--- a/mailtrap/api/resources/inbound_threads.py
+++ b/mailtrap/api/resources/inbound_threads.py
@@ -1,0 +1,41 @@
+from typing import Any
+from typing import Optional
+
+from mailtrap.http import HttpClient
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import InboundThread
+from mailtrap.models.inbound import InboundThreadsListResponse
+
+
+class InboundThreadsApi:
+    def __init__(self, client: HttpClient) -> None:
+        self._client = client
+
+    def get_list(
+        self, inbox_id: int, last_id: Optional[str] = None
+    ) -> InboundThreadsListResponse:
+        """
+        List conversation threads in an inbox. Pass last_id from a previous
+        response to fetch the next page.
+        """
+        params: dict[str, Any] = {}
+        if last_id:
+            params["last_id"] = last_id
+        response = self._client.get(self._api_path(inbox_id), params=params or None)
+        return InboundThreadsListResponse(**response)
+
+    def get_by_id(self, inbox_id: int, thread_id: str) -> InboundThread:
+        """Get a single thread with its messages embedded (oldest first)."""
+        response = self._client.get(self._api_path(inbox_id, thread_id))
+        return InboundThread(**response)
+
+    def delete(self, inbox_id: int, thread_id: str) -> DeletedObject:
+        """Delete a thread."""
+        self._client.delete(self._api_path(inbox_id, thread_id))
+        return DeletedObject(thread_id)
+
+    def _api_path(self, inbox_id: int, thread_id: Optional[str] = None) -> str:
+        path = f"/api/inbound/inboxes/{inbox_id}/threads"
+        if thread_id:
+            return f"{path}/{thread_id}"
+        return path

--- a/mailtrap/client.py
+++ b/mailtrap/client.py
@@ -9,6 +9,7 @@ from pydantic import TypeAdapter
 from mailtrap.api.contacts import ContactsBaseApi
 from mailtrap.api.email_logs import EmailLogsBaseApi
 from mailtrap.api.general import GeneralApi
+from mailtrap.api.inbound import InboundBaseApi
 from mailtrap.api.organizations import OrganizationsBaseApi
 from mailtrap.api.resources.stats import StatsApi
 from mailtrap.api.sending import SendingApi
@@ -73,6 +74,12 @@ class MailtrapClient:
     @property
     def general_api(self) -> GeneralApi:
         return GeneralApi(
+            client=HttpClient(host=GENERAL_HOST, headers=self.headers),
+        )
+
+    @property
+    def inbound_api(self) -> InboundBaseApi:
+        return InboundBaseApi(
             client=HttpClient(host=GENERAL_HOST, headers=self.headers),
         )
 

--- a/mailtrap/models/email_logs.py
+++ b/mailtrap/models/email_logs.py
@@ -134,6 +134,10 @@ class EmailLogMessage(BaseModel):
     message_id: str
     status: Literal["delivered", "not_delivered", "enqueued", "opted_out"]
     subject: Optional[str] = None
+    rfc_message_id: Optional[str] = None
+    in_reply_to: Optional[str] = None
+    references: list[str] = Field(default_factory=list)
+    thread_id: Optional[str] = None
     from_: str = Field(alias="from")
     to: str
     sent_at: str
@@ -161,6 +165,8 @@ class EmailLogMessage(BaseModel):
             payload["custom_variables"] = {}
         if payload.get("template_variables") is None:
             payload["template_variables"] = {}
+        if payload.get("references") is None:
+            payload["references"] = []
         return cls(**payload)
 
 

--- a/mailtrap/models/inbound.py
+++ b/mailtrap/models/inbound.py
@@ -1,0 +1,237 @@
+"""Models for the Inbound Email API (folders, inboxes, messages, threads)."""
+
+from typing import Any
+from typing import Literal
+from typing import Optional
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+from mailtrap.models.common import RequestParams
+from mailtrap.models.mail.address import Address
+from mailtrap.models.mail.attachment import Attachment
+
+ContentDisposition = Literal["attachment", "inline"]
+
+# --- Attachments ---
+
+
+@dataclass
+class InboundAttachment:
+    """
+    Attachment metadata on a received message. download_url and
+    download_url_expires_at are only populated on get-by-id and thread responses.
+    """
+
+    attachment_id: str
+    size: Optional[int] = None
+    filename: Optional[str] = None
+    content_type: Optional[str] = None
+    content_disposition: Optional[ContentDisposition] = None
+    content_id: Optional[str] = None
+    download_url: Optional[str] = None
+    download_url_expires_at: Optional[str] = None
+
+
+# --- Folders ---
+
+
+@dataclass
+class InboundFolder:
+    id: int
+    name: str
+
+
+# --- Inboxes ---
+
+
+@dataclass
+class InboundInbox:
+    id: int
+    name: str
+    address: str
+    domain_id: int
+
+
+# --- Messages ---
+
+
+class InboundMessage(BaseModel):
+    """A received message (list / summary shape)."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    inbox_id: int
+    from_: Optional[str] = Field(default=None, alias="from")
+    to: list[str] = Field(default_factory=list)
+    cc: list[str] = Field(default_factory=list)
+    bcc: list[str] = Field(default_factory=list)
+    reply_to: Optional[str] = None
+    subject: Optional[str] = None
+    rfc_message_id: Optional[str] = None
+    in_reply_to: Optional[str] = None
+    references: list[str] = Field(default_factory=list)
+    headers: Optional[dict[str, str]] = None
+    size: Optional[int] = None
+    html_size: Optional[int] = None
+    text_size: Optional[int] = None
+    received_at: str
+    thread_id: Optional[str] = None
+    attachments: list[InboundAttachment] = Field(default_factory=list)
+
+
+class InboundMessageDetails(InboundMessage):
+    """A received message with body and attachment download URLs (get-by-id)."""
+
+    raw_message_url: Optional[str] = None
+    raw_message_expires_at: Optional[str] = None
+    html_body: Optional[str] = None
+    text_body: Optional[str] = None
+
+
+@dataclass
+class InboundMessagesListResponse:
+    """Paginated response from list messages (cursor via last_id)."""
+
+    data: list[InboundMessage] = Field(default_factory=list)
+    total_count: int = 0
+    last_id: Optional[str] = None
+
+
+# --- Threads ---
+
+
+class InboundThreadSummary(BaseModel):
+    """Thread overview (list shape and the head of a thread)."""
+
+    id: str
+    subject: Optional[str] = None
+    message_count: int
+    size: int
+    first_message_at: str
+    last_received_at: Optional[str] = None
+    last_sent_at: Optional[str] = None
+    last_activity_at: str
+    last_message_id: Optional[str] = None
+    senders: list[str] = Field(default_factory=list)
+    recipients: list[str] = Field(default_factory=list)
+    attachments: list[InboundAttachment] = Field(default_factory=list)
+
+
+class InboundThreadMessage(BaseModel):
+    """
+    A message inside a thread. Only visibility_status and direction are
+    guaranteed; placeholder entries omit the rest.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    visibility_status: Literal["available", "placeholder"]
+    direction: Literal["inbound", "outbound"]
+    id: Optional[str] = None
+    message_group_id: Optional[str] = None
+    subject: Optional[str] = None
+    rfc_message_id: Optional[str] = None
+    in_reply_to: Optional[str] = None
+    references: Optional[list[str]] = None
+    from_: Optional[str] = Field(default=None, alias="from")
+    to: Optional[list[str]] = None
+    cc: Optional[list[str]] = None
+    bcc: Optional[list[str]] = None
+    reply_to: Optional[str] = None
+    created_at: Optional[str] = None
+    email_size: Optional[int] = None
+    text_body: Optional[str] = None
+    html_body: Optional[str] = None
+    attachments: Optional[list[InboundAttachment]] = None
+    delivery_status: Optional[str] = None
+    delivered_at: Optional[str] = None
+    bounced_at: Optional[str] = None
+
+
+class InboundThread(InboundThreadSummary):
+    """A thread with its messages embedded (oldest first)."""
+
+    messages: list[InboundThreadMessage] = Field(default_factory=list)
+
+
+@dataclass
+class InboundThreadsListResponse:
+    """Paginated response from list threads (cursor via last_id)."""
+
+    data: list[InboundThreadSummary] = Field(default_factory=list)
+    total_count: int = 0
+    last_id: Optional[str] = None
+
+
+@dataclass
+class InboundSendResult:
+    """Result of a reply, reply-all, or forward (sends a real email)."""
+
+    message_ids: list[str] = Field(default_factory=list)
+
+
+# --- Request params ---
+
+
+@dataclass
+class CreateInboundFolderParams(RequestParams):
+    name: str
+
+
+@dataclass
+class UpdateInboundFolderParams(RequestParams):
+    name: str
+
+
+@dataclass
+class CreateInboundInboxParams(RequestParams):
+    """Omit domain_id for a Mailtrap-hosted inbox; pass it for a custom-domain inbox."""
+
+    name: str
+    domain_id: Optional[int] = None
+
+
+@dataclass
+class UpdateInboundInboxParams(RequestParams):
+    name: str
+
+
+@dataclass
+class _InboundMessageParams(RequestParams):
+    """
+    Shared body for replying to and forwarding an inbound message. `sender`
+    (serialized as `from`) is rejected for Mailtrap-hosted inboxes and required
+    for custom-domain inboxes.
+    """
+
+    sender: Optional[Address] = Field(default=None, serialization_alias="from")
+    to: Optional[list[Address]] = None
+    cc: Optional[list[Address]] = None
+    bcc: Optional[list[Address]] = None
+    reply_to: Optional[Address] = None
+    text: Optional[str] = None
+    html: Optional[str] = None
+    category: Optional[str] = None
+    attachments: Optional[list[Attachment]] = None
+    headers: Optional[dict[str, str]] = None
+    custom_variables: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class ReplyInboundMessageParams(_InboundMessageParams):
+    """Body for replying to (or reply-all-ing) an inbound message."""
+
+
+@dataclass
+class ForwardInboundMessageParams(_InboundMessageParams):
+    """Forward an inbound message; requires at least one recipient in `to`."""
+
+    to: list[Address] = Field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.to:
+            raise ValueError("`to` must contain at least one recipient for forward")

--- a/mailtrap/models/sending_domains.py
+++ b/mailtrap/models/sending_domains.py
@@ -40,6 +40,8 @@ class SendingDomain:
     alert_recipient_email: Optional[str] = None
     dns_verified_at: Optional[str] = None
     dns_records: list[DnsRecord] = Field(default_factory=list)
+    inbound_enabled: Optional[bool] = None
+    inbound_verified: Optional[bool] = None
 
 
 @dataclass

--- a/mailtrap/models/webhooks.py
+++ b/mailtrap/models/webhooks.py
@@ -15,6 +15,7 @@ class Webhook:
     payload_format: str
     sending_stream: Optional[str] = None
     domain_id: Optional[int] = None
+    inbound_inbox_id: Optional[int] = None
     event_types: list[str] = Field(default_factory=list)
 
 
@@ -47,6 +48,7 @@ class CreateWebhookParams(RequestParams):
     sending_stream: Optional[str] = None
     event_types: Optional[list[str]] = None
     domain_id: Optional[int] = None
+    inbound_inbox_id: Optional[int] = None
 
 
 @dataclass
@@ -55,3 +57,4 @@ class UpdateWebhookParams(RequestParams):
     active: Optional[bool] = None
     payload_format: Optional[str] = None
     event_types: Optional[list[str]] = None
+    inbound_inbox_id: Optional[int] = None

--- a/tests/unit/api/inbound/test_inbound_folders.py
+++ b/tests/unit/api/inbound/test_inbound_folders.py
@@ -1,0 +1,109 @@
+import pytest
+import responses
+
+from mailtrap.api.resources.inbound_folders import InboundFoldersApi
+from mailtrap.config import GENERAL_HOST
+from mailtrap.exceptions import APIError
+from mailtrap.http import HttpClient
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import CreateInboundFolderParams
+from mailtrap.models.inbound import InboundFolder
+from mailtrap.models.inbound import UpdateInboundFolderParams
+from tests import conftest
+
+FOLDER_ID = 42
+BASE_URL = f"https://{GENERAL_HOST}/api/inbound/folders"
+
+ERROR_CASES = [
+    (
+        conftest.UNAUTHORIZED_STATUS_CODE,
+        conftest.UNAUTHORIZED_RESPONSE,
+        conftest.UNAUTHORIZED_ERROR_MESSAGE,
+    ),
+    (
+        conftest.NOT_FOUND_STATUS_CODE,
+        conftest.NOT_FOUND_RESPONSE,
+        conftest.NOT_FOUND_ERROR_MESSAGE,
+    ),
+]
+
+
+@pytest.fixture
+def folders_api() -> InboundFoldersApi:
+    return InboundFoldersApi(client=HttpClient(GENERAL_HOST))
+
+
+class TestInboundFoldersApi:
+
+    @responses.activate
+    def test_get_list_should_return_folders(self, folders_api: InboundFoldersApi) -> None:
+        responses.get(BASE_URL, json=[{"id": FOLDER_ID, "name": "Support"}], status=200)
+
+        folders = folders_api.get_list()
+
+        assert all(isinstance(f, InboundFolder) for f in folders)
+        assert folders[0].id == FOLDER_ID
+        assert folders[0].name == "Support"
+
+    @pytest.mark.parametrize(
+        "status_code,response_json,expected_error_message", ERROR_CASES
+    )
+    @responses.activate
+    def test_get_list_should_raise_api_errors(
+        self,
+        folders_api: InboundFoldersApi,
+        status_code: int,
+        response_json: dict,
+        expected_error_message: str,
+    ) -> None:
+        responses.get(BASE_URL, status=status_code, json=response_json)
+
+        with pytest.raises(APIError) as exc_info:
+            folders_api.get_list()
+
+        assert expected_error_message in str(exc_info.value)
+
+    @responses.activate
+    def test_get_by_id_should_return_folder(self, folders_api: InboundFoldersApi) -> None:
+        responses.get(
+            f"{BASE_URL}/{FOLDER_ID}",
+            json={"id": FOLDER_ID, "name": "Support"},
+            status=200,
+        )
+
+        folder = folders_api.get_by_id(FOLDER_ID)
+
+        assert isinstance(folder, InboundFolder)
+        assert folder.id == FOLDER_ID
+
+    @responses.activate
+    def test_create_should_return_folder(self, folders_api: InboundFoldersApi) -> None:
+        responses.post(BASE_URL, json={"id": FOLDER_ID, "name": "Support"}, status=200)
+
+        folder = folders_api.create(CreateInboundFolderParams(name="Support"))
+
+        assert folder.id == FOLDER_ID
+        assert responses.calls[-1].request.body == b'{"name": "Support"}'
+
+    @responses.activate
+    def test_update_should_return_folder(self, folders_api: InboundFoldersApi) -> None:
+        responses.patch(
+            f"{BASE_URL}/{FOLDER_ID}",
+            json={"id": FOLDER_ID, "name": "Renamed"},
+            status=200,
+        )
+
+        folder = folders_api.update(FOLDER_ID, UpdateInboundFolderParams(name="Renamed"))
+
+        assert folder.name == "Renamed"
+
+    @responses.activate
+    def test_delete_should_return_deleted_object(
+        self, folders_api: InboundFoldersApi
+    ) -> None:
+        responses.delete(f"{BASE_URL}/{FOLDER_ID}", status=204)
+
+        deleted = folders_api.delete(FOLDER_ID)
+
+        assert isinstance(deleted, DeletedObject)
+        assert deleted.id == FOLDER_ID

--- a/tests/unit/api/inbound/test_inbound_inboxes.py
+++ b/tests/unit/api/inbound/test_inbound_inboxes.py
@@ -1,0 +1,125 @@
+import pytest
+import responses
+
+from mailtrap.api.resources.inbound_inboxes import InboundInboxesApi
+from mailtrap.config import GENERAL_HOST
+from mailtrap.exceptions import APIError
+from mailtrap.http import HttpClient
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import CreateInboundInboxParams
+from mailtrap.models.inbound import InboundInbox
+from mailtrap.models.inbound import UpdateInboundInboxParams
+from tests import conftest
+
+FOLDER_ID = 42
+INBOX_ID = 9
+BASE_URL = f"https://{GENERAL_HOST}/api/inbound/folders/{FOLDER_ID}/inboxes"
+
+
+def _inbox_dict() -> dict:
+    return {
+        "id": INBOX_ID,
+        "name": "Tickets",
+        "address": "tickets@inbound.example.com",
+        "domain_id": 3,
+    }
+
+
+@pytest.fixture
+def inboxes_api() -> InboundInboxesApi:
+    return InboundInboxesApi(client=HttpClient(GENERAL_HOST))
+
+
+class TestInboundInboxesApi:
+
+    @responses.activate
+    def test_get_list_should_return_inboxes(self, inboxes_api: InboundInboxesApi) -> None:
+        responses.get(BASE_URL, json=[_inbox_dict()], status=200)
+
+        inboxes = inboxes_api.get_list(FOLDER_ID)
+
+        assert all(isinstance(i, InboundInbox) for i in inboxes)
+        assert inboxes[0].id == INBOX_ID
+        assert inboxes[0].address == "tickets@inbound.example.com"
+
+    @responses.activate
+    def test_get_by_id_should_return_inbox(self, inboxes_api: InboundInboxesApi) -> None:
+        responses.get(f"{BASE_URL}/{INBOX_ID}", json=_inbox_dict(), status=200)
+
+        inbox = inboxes_api.get_by_id(FOLDER_ID, INBOX_ID)
+
+        assert isinstance(inbox, InboundInbox)
+        assert inbox.domain_id == 3
+
+    @responses.activate
+    def test_create_should_send_flat_body_and_return_inbox(
+        self, inboxes_api: InboundInboxesApi
+    ) -> None:
+        responses.post(BASE_URL, json=_inbox_dict(), status=200)
+
+        params = CreateInboundInboxParams(name="Tickets", domain_id=3)
+        inbox = inboxes_api.create(FOLDER_ID, params)
+
+        assert inbox.id == INBOX_ID
+        assert responses.calls[-1].request.body == b'{"name": "Tickets", "domain_id": 3}'
+
+    @responses.activate
+    def test_create_should_omit_domain_id_when_not_set(
+        self, inboxes_api: InboundInboxesApi
+    ) -> None:
+        responses.post(BASE_URL, json=_inbox_dict(), status=200)
+
+        inboxes_api.create(FOLDER_ID, CreateInboundInboxParams(name="Tickets"))
+
+        assert responses.calls[-1].request.body == b'{"name": "Tickets"}'
+
+    @pytest.mark.parametrize(
+        "status_code,response_json,expected_error_message",
+        [
+            (
+                conftest.UNAUTHORIZED_STATUS_CODE,
+                conftest.UNAUTHORIZED_RESPONSE,
+                conftest.UNAUTHORIZED_ERROR_MESSAGE,
+            ),
+            (
+                conftest.VALIDATION_ERRORS_STATUS_CODE,
+                {"errors": {"name": ["can't be blank"]}},
+                "name: can't be blank",
+            ),
+        ],
+    )
+    @responses.activate
+    def test_create_should_raise_api_errors(
+        self,
+        inboxes_api: InboundInboxesApi,
+        status_code: int,
+        response_json: dict,
+        expected_error_message: str,
+    ) -> None:
+        responses.post(BASE_URL, status=status_code, json=response_json)
+
+        with pytest.raises(APIError) as exc_info:
+            inboxes_api.create(FOLDER_ID, CreateInboundInboxParams(name=""))
+
+        assert expected_error_message in str(exc_info.value)
+
+    @responses.activate
+    def test_update_should_return_inbox(self, inboxes_api: InboundInboxesApi) -> None:
+        responses.patch(f"{BASE_URL}/{INBOX_ID}", json=_inbox_dict(), status=200)
+
+        inbox = inboxes_api.update(
+            FOLDER_ID, INBOX_ID, UpdateInboundInboxParams(name="Tickets")
+        )
+
+        assert inbox.id == INBOX_ID
+
+    @responses.activate
+    def test_delete_should_return_deleted_object(
+        self, inboxes_api: InboundInboxesApi
+    ) -> None:
+        responses.delete(f"{BASE_URL}/{INBOX_ID}", status=204)
+
+        deleted = inboxes_api.delete(FOLDER_ID, INBOX_ID)
+
+        assert isinstance(deleted, DeletedObject)
+        assert deleted.id == INBOX_ID

--- a/tests/unit/api/inbound/test_inbound_messages.py
+++ b/tests/unit/api/inbound/test_inbound_messages.py
@@ -1,0 +1,187 @@
+import pytest
+import responses
+
+from mailtrap.api.resources.inbound_messages import InboundMessagesApi
+from mailtrap.config import GENERAL_HOST
+from mailtrap.exceptions import APIError
+from mailtrap.http import HttpClient
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import ForwardInboundMessageParams
+from mailtrap.models.inbound import InboundMessageDetails
+from mailtrap.models.inbound import InboundMessagesListResponse
+from mailtrap.models.inbound import InboundSendResult
+from mailtrap.models.inbound import ReplyInboundMessageParams
+from mailtrap.models.mail.address import Address
+from tests import conftest
+
+INBOX_ID = 9
+MESSAGE_ID = "1871574677877796928"
+BASE_URL = f"https://{GENERAL_HOST}/api/inbound/inboxes/{INBOX_ID}/messages"
+
+
+@pytest.fixture
+def messages_api() -> InboundMessagesApi:
+    return InboundMessagesApi(client=HttpClient(GENERAL_HOST))
+
+
+class TestInboundMessagesApi:
+
+    @responses.activate
+    def test_get_list_should_return_page(self, messages_api: InboundMessagesApi) -> None:
+        responses.get(
+            BASE_URL,
+            json={
+                "data": [
+                    {
+                        "id": MESSAGE_ID,
+                        "inbox_id": INBOX_ID,
+                        "from": "customer@example.com",
+                        "subject": "Question",
+                        "received_at": "2026-01-15T10:30:00Z",
+                    }
+                ],
+                "total_count": 1,
+                "last_id": MESSAGE_ID,
+            },
+            status=200,
+        )
+
+        page = messages_api.get_list(INBOX_ID)
+
+        assert isinstance(page, InboundMessagesListResponse)
+        assert page.total_count == 1
+        assert page.last_id == MESSAGE_ID
+        assert page.data[0].from_ == "customer@example.com"
+
+    @responses.activate
+    def test_get_list_should_pass_last_id_cursor(
+        self, messages_api: InboundMessagesApi
+    ) -> None:
+        responses.get(
+            BASE_URL, json={"data": [], "total_count": 0, "last_id": None}, status=200
+        )
+
+        messages_api.get_list(INBOX_ID, last_id="cursor-1")
+
+        assert "last_id=cursor-1" in responses.calls[-1].request.url
+
+    @responses.activate
+    def test_get_by_id_should_return_details(
+        self, messages_api: InboundMessagesApi
+    ) -> None:
+        responses.get(
+            f"{BASE_URL}/{MESSAGE_ID}",
+            json={
+                "id": MESSAGE_ID,
+                "inbox_id": INBOX_ID,
+                "from": "customer@example.com",
+                "received_at": "2026-01-15T10:30:00Z",
+                "html_body": "<p>Hi</p>",
+                "attachments": [{"attachment_id": "a1", "download_url": "https://x/a1"}],
+            },
+            status=200,
+        )
+
+        message = messages_api.get_by_id(INBOX_ID, MESSAGE_ID)
+
+        assert isinstance(message, InboundMessageDetails)
+        assert message.html_body == "<p>Hi</p>"
+        assert message.attachments[0].download_url == "https://x/a1"
+
+    @responses.activate
+    def test_delete_should_return_deleted_object(
+        self, messages_api: InboundMessagesApi
+    ) -> None:
+        responses.delete(f"{BASE_URL}/{MESSAGE_ID}", status=204)
+
+        deleted = messages_api.delete(INBOX_ID, MESSAGE_ID)
+
+        assert isinstance(deleted, DeletedObject)
+        assert deleted.id == MESSAGE_ID
+
+    @responses.activate
+    def test_reply_should_send_flat_body_and_return_result(
+        self, messages_api: InboundMessagesApi
+    ) -> None:
+        responses.post(
+            f"{BASE_URL}/{MESSAGE_ID}/reply",
+            json={"message_ids": ["s1"]},
+            status=200,
+        )
+
+        result = messages_api.reply(
+            INBOX_ID, MESSAGE_ID, ReplyInboundMessageParams(text="Thanks!")
+        )
+
+        assert isinstance(result, InboundSendResult)
+        assert result.message_ids == ["s1"]
+        assert responses.calls[-1].request.body == b'{"text": "Thanks!"}'
+
+    @responses.activate
+    def test_reply_all_should_return_result(
+        self, messages_api: InboundMessagesApi
+    ) -> None:
+        responses.post(
+            f"{BASE_URL}/{MESSAGE_ID}/reply_all",
+            json={"message_ids": ["s1", "s2"]},
+            status=200,
+        )
+
+        result = messages_api.reply_all(
+            INBOX_ID, MESSAGE_ID, ReplyInboundMessageParams(text="All")
+        )
+
+        assert result.message_ids == ["s1", "s2"]
+
+    @responses.activate
+    def test_forward_should_serialize_recipients_and_return_result(
+        self, messages_api: InboundMessagesApi
+    ) -> None:
+        responses.post(
+            f"{BASE_URL}/{MESSAGE_ID}/forward",
+            json={"message_ids": ["s1"]},
+            status=200,
+        )
+
+        params = ForwardInboundMessageParams(to=[Address(email="colleague@example.com")])
+        result = messages_api.forward(INBOX_ID, MESSAGE_ID, params)
+
+        assert result.message_ids == ["s1"]
+        assert (
+            responses.calls[-1].request.body
+            == b'{"to": [{"email": "colleague@example.com"}]}'
+        )
+
+    @pytest.mark.parametrize(
+        "status_code,response_json,expected_error_message",
+        [
+            (
+                conftest.UNAUTHORIZED_STATUS_CODE,
+                conftest.UNAUTHORIZED_RESPONSE,
+                conftest.UNAUTHORIZED_ERROR_MESSAGE,
+            ),
+            (
+                conftest.NOT_FOUND_STATUS_CODE,
+                conftest.NOT_FOUND_RESPONSE,
+                conftest.NOT_FOUND_ERROR_MESSAGE,
+            ),
+        ],
+    )
+    @responses.activate
+    def test_reply_should_raise_api_errors(
+        self,
+        messages_api: InboundMessagesApi,
+        status_code: int,
+        response_json: dict,
+        expected_error_message: str,
+    ) -> None:
+        responses.post(
+            f"{BASE_URL}/{MESSAGE_ID}/reply", status=status_code, json=response_json
+        )
+
+        with pytest.raises(APIError) as exc_info:
+            messages_api.reply(
+                INBOX_ID, MESSAGE_ID, ReplyInboundMessageParams(text="Thanks!")
+            )
+
+        assert expected_error_message in str(exc_info.value)

--- a/tests/unit/api/inbound/test_inbound_threads.py
+++ b/tests/unit/api/inbound/test_inbound_threads.py
@@ -1,0 +1,133 @@
+import pytest
+import responses
+
+from mailtrap.api.resources.inbound_threads import InboundThreadsApi
+from mailtrap.config import GENERAL_HOST
+from mailtrap.exceptions import APIError
+from mailtrap.http import HttpClient
+from mailtrap.models.common import DeletedObject
+from mailtrap.models.inbound import InboundThread
+from mailtrap.models.inbound import InboundThreadsListResponse
+from tests import conftest
+
+INBOX_ID = 9
+THREAD_ID = "1871574677878845504"
+BASE_URL = f"https://{GENERAL_HOST}/api/inbound/inboxes/{INBOX_ID}/threads"
+
+
+@pytest.fixture
+def threads_api() -> InboundThreadsApi:
+    return InboundThreadsApi(client=HttpClient(GENERAL_HOST))
+
+
+class TestInboundThreadsApi:
+
+    @responses.activate
+    def test_get_list_should_return_page(self, threads_api: InboundThreadsApi) -> None:
+        responses.get(
+            BASE_URL,
+            json={
+                "data": [
+                    {
+                        "id": THREAD_ID,
+                        "subject": "Billing",
+                        "message_count": 2,
+                        "size": 100,
+                        "first_message_at": "2026-01-15T10:00:00Z",
+                        "last_activity_at": "2026-01-15T11:00:00Z",
+                    }
+                ],
+                "total_count": 1,
+                "last_id": THREAD_ID,
+            },
+            status=200,
+        )
+
+        page = threads_api.get_list(INBOX_ID)
+
+        assert isinstance(page, InboundThreadsListResponse)
+        assert page.total_count == 1
+        assert page.data[0].message_count == 2
+
+    @responses.activate
+    def test_get_list_should_pass_last_id_cursor(
+        self, threads_api: InboundThreadsApi
+    ) -> None:
+        responses.get(
+            BASE_URL, json={"data": [], "total_count": 0, "last_id": None}, status=200
+        )
+
+        threads_api.get_list(INBOX_ID, last_id="cursor-1")
+
+        assert "last_id=cursor-1" in responses.calls[-1].request.url
+
+    @responses.activate
+    def test_get_by_id_should_return_thread_with_messages(
+        self, threads_api: InboundThreadsApi
+    ) -> None:
+        responses.get(
+            f"{BASE_URL}/{THREAD_ID}",
+            json={
+                "id": THREAD_ID,
+                "subject": "Billing",
+                "message_count": 1,
+                "size": 50,
+                "first_message_at": "2026-01-15T10:00:00Z",
+                "last_activity_at": "2026-01-15T10:00:00Z",
+                "messages": [
+                    {
+                        "visibility_status": "available",
+                        "direction": "inbound",
+                        "from": "customer@example.com",
+                    }
+                ],
+            },
+            status=200,
+        )
+
+        thread = threads_api.get_by_id(INBOX_ID, THREAD_ID)
+
+        assert isinstance(thread, InboundThread)
+        assert thread.messages[0].direction == "inbound"
+        assert thread.messages[0].from_ == "customer@example.com"
+
+    @pytest.mark.parametrize(
+        "status_code,response_json,expected_error_message",
+        [
+            (
+                conftest.UNAUTHORIZED_STATUS_CODE,
+                conftest.UNAUTHORIZED_RESPONSE,
+                conftest.UNAUTHORIZED_ERROR_MESSAGE,
+            ),
+            (
+                conftest.NOT_FOUND_STATUS_CODE,
+                conftest.NOT_FOUND_RESPONSE,
+                conftest.NOT_FOUND_ERROR_MESSAGE,
+            ),
+        ],
+    )
+    @responses.activate
+    def test_get_by_id_should_raise_api_errors(
+        self,
+        threads_api: InboundThreadsApi,
+        status_code: int,
+        response_json: dict,
+        expected_error_message: str,
+    ) -> None:
+        responses.get(f"{BASE_URL}/{THREAD_ID}", status=status_code, json=response_json)
+
+        with pytest.raises(APIError) as exc_info:
+            threads_api.get_by_id(INBOX_ID, THREAD_ID)
+
+        assert expected_error_message in str(exc_info.value)
+
+    @responses.activate
+    def test_delete_should_return_deleted_object(
+        self, threads_api: InboundThreadsApi
+    ) -> None:
+        responses.delete(f"{BASE_URL}/{THREAD_ID}", status=204)
+
+        deleted = threads_api.delete(INBOX_ID, THREAD_ID)
+
+        assert isinstance(deleted, DeletedObject)
+        assert deleted.id == THREAD_ID

--- a/tests/unit/models/test_email_log_models.py
+++ b/tests/unit/models/test_email_log_models.py
@@ -41,6 +41,35 @@ class TestEmailLogMessage:
         assert msg.status == "delivered"
         assert msg.raw_message_url is None
         assert msg.events == []
+        # threading fields default when absent
+        assert msg.rfc_message_id is None
+        assert msg.in_reply_to is None
+        assert msg.references == []
+        assert msg.thread_id is None
+
+    def test_parses_threading_fields_when_present(self) -> None:
+        data: dict[str, Any] = {
+            "message_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "status": "delivered",
+            "from": "sender@example.com",
+            "to": "recipient@example.com",
+            "sent_at": "2025-01-15T10:30:00Z",
+            "custom_variables": {},
+            "sending_stream": "transactional",
+            "sending_domain_id": 3938,
+            "template_variables": {},
+            "opens_count": 0,
+            "clicks_count": 0,
+            "rfc_message_id": "<abc@example.com>",
+            "in_reply_to": "<parent@example.com>",
+            "references": ["<root@example.com>", "<parent@example.com>"],
+            "thread_id": "thread-1",
+        }
+        msg = EmailLogMessage.from_api(data)
+        assert msg.rfc_message_id == "<abc@example.com>"
+        assert msg.in_reply_to == "<parent@example.com>"
+        assert msg.references == ["<root@example.com>", "<parent@example.com>"]
+        assert msg.thread_id == "thread-1"
 
     def test_from_api_handles_from_and_events(self) -> None:
         data: dict[str, Any] = {

--- a/tests/unit/models/test_inbound.py
+++ b/tests/unit/models/test_inbound.py
@@ -1,0 +1,75 @@
+import pytest
+
+from mailtrap.models.inbound import CreateInboundFolderParams
+from mailtrap.models.inbound import CreateInboundInboxParams
+from mailtrap.models.inbound import ForwardInboundMessageParams
+from mailtrap.models.inbound import InboundMessage
+from mailtrap.models.inbound import InboundThread
+from mailtrap.models.inbound import ReplyInboundMessageParams
+from mailtrap.models.mail.address import Address
+
+
+class TestInboundParams:
+    def test_create_folder_api_data(self) -> None:
+        assert CreateInboundFolderParams(name="Support").api_data == {"name": "Support"}
+
+    def test_create_inbox_includes_domain_id(self) -> None:
+        params = CreateInboundInboxParams(name="Tickets", domain_id=3)
+        assert params.api_data == {"name": "Tickets", "domain_id": 3}
+
+    def test_create_inbox_omits_domain_id_when_none(self) -> None:
+        assert CreateInboundInboxParams(name="Tickets").api_data == {"name": "Tickets"}
+
+    def test_reply_serializes_sender_as_from_and_excludes_none(self) -> None:
+        params = ReplyInboundMessageParams(
+            sender=Address(email="me@example.com"), text="Thanks!"
+        )
+        assert params.api_data == {
+            "from": {"email": "me@example.com"},
+            "text": "Thanks!",
+        }
+
+    def test_forward_serializes_recipients(self) -> None:
+        params = ForwardInboundMessageParams(
+            to=[Address(email="colleague@example.com")], text="FYI"
+        )
+        assert params.api_data == {
+            "to": [{"email": "colleague@example.com"}],
+            "text": "FYI",
+        }
+
+    def test_forward_requires_at_least_one_recipient(self) -> None:
+        with pytest.raises(ValueError):
+            ForwardInboundMessageParams(to=[])
+
+
+class TestInboundResponseModels:
+    def test_message_parses_from_alias_and_attachments(self) -> None:
+        message = InboundMessage(
+            **{
+                "id": "m1",
+                "inbox_id": 9,
+                "from": "customer@example.com",
+                "received_at": "2026-01-15T10:30:00Z",
+                "attachments": [{"attachment_id": "a1", "download_url": "https://x/a1"}],
+            }
+        )
+        assert message.from_ == "customer@example.com"
+        assert message.attachments[0].download_url == "https://x/a1"
+        assert message.to == []
+
+    def test_thread_parses_nested_messages(self) -> None:
+        thread = InboundThread(
+            **{
+                "id": "t1",
+                "message_count": 1,
+                "size": 10,
+                "first_message_at": "2026-01-15T10:00:00Z",
+                "last_activity_at": "2026-01-15T10:00:00Z",
+                "messages": [
+                    {"visibility_status": "placeholder", "direction": "outbound"}
+                ],
+            }
+        )
+        assert thread.messages[0].visibility_status == "placeholder"
+        assert thread.messages[0].from_ is None

--- a/tests/unit/models/test_sending_domains.py
+++ b/tests/unit/models/test_sending_domains.py
@@ -1,5 +1,44 @@
 from mailtrap.models.sending_domains import CreateSendingDomainParams
+from mailtrap.models.sending_domains import SendingDomain
 from mailtrap.models.sending_domains import SendSetupInstructionsParams
+
+
+def _sending_domain_dict() -> dict:
+    return {
+        "id": 1,
+        "domain_name": "example.com",
+        "demo": False,
+        "compliance_status": "verified",
+        "dns_verified": True,
+        "open_tracking_enabled": True,
+        "click_tracking_enabled": True,
+        "auto_unsubscribe_link_enabled": False,
+        "custom_domain_tracking_enabled": False,
+        "health_alerts_enabled": True,
+        "critical_alerts_enabled": True,
+        "permissions": {
+            "can_read": True,
+            "can_update": True,
+            "can_destroy": True,
+        },
+    }
+
+
+class TestSendingDomain:
+    def test_parses_inbound_flags_when_present(self) -> None:
+        data = {
+            **_sending_domain_dict(),
+            "inbound_enabled": True,
+            "inbound_verified": False,
+        }
+        domain = SendingDomain(**data)
+        assert domain.inbound_enabled is True
+        assert domain.inbound_verified is False
+
+    def test_inbound_flags_default_when_absent(self) -> None:
+        domain = SendingDomain(**_sending_domain_dict())
+        assert domain.inbound_enabled is None
+        assert domain.inbound_verified is None
 
 
 class TestCreateSendingDomainParams:

--- a/tests/unit/models/test_webhooks.py
+++ b/tests/unit/models/test_webhooks.py
@@ -1,0 +1,47 @@
+from mailtrap.models.webhooks import CreateWebhookParams
+from mailtrap.models.webhooks import UpdateWebhookParams
+from mailtrap.models.webhooks import Webhook
+
+
+class TestWebhook:
+    def test_parses_inbound_receiving_webhook(self) -> None:
+        webhook = Webhook(
+            id=1,
+            url="https://example.com/hook",
+            active=True,
+            webhook_type="inbound_receiving",
+            payload_format="json",
+            inbound_inbox_id=665,
+        )
+        assert webhook.webhook_type == "inbound_receiving"
+        assert webhook.inbound_inbox_id == 665
+
+    def test_inbound_inbox_id_defaults_to_none(self) -> None:
+        webhook = Webhook(
+            id=1,
+            url="https://example.com/hook",
+            active=True,
+            webhook_type="email_sending",
+            payload_format="json",
+        )
+        assert webhook.inbound_inbox_id is None
+
+
+class TestCreateWebhookParams:
+    def test_api_data_includes_inbound_inbox_id(self) -> None:
+        params = CreateWebhookParams(
+            url="https://example.com/hook",
+            webhook_type="inbound_receiving",
+            inbound_inbox_id=665,
+        )
+        assert params.api_data == {
+            "url": "https://example.com/hook",
+            "webhook_type": "inbound_receiving",
+            "inbound_inbox_id": 665,
+        }
+
+
+class TestUpdateWebhookParams:
+    def test_api_data_includes_inbound_inbox_id(self) -> None:
+        params = UpdateWebhookParams(inbound_inbox_id=665)
+        assert params.api_data == {"inbound_inbox_id": 665}


### PR DESCRIPTION
## Summary

Adds Inbound Email API support to the Python SDK, matching the released Node and Ruby SDKs. Exposed as `client.inbound_api` (token-scoped — no `account_id` required, mirroring `general_api`).

- **Folders** — `client.inbound_api.folders`: `get_list` / `get_by_id` / `create` / `update` / `delete`
- **Inboxes** — `client.inbound_api.inboxes`: folder-scoped CRUD (`create` takes optional `domain_id`)
- **Messages** — `client.inbound_api.messages`: `get_list` (cursor via `last_id`) / `get_by_id` / `delete` + `reply` / `reply_all` / `forward` (send real email)
- **Threads** — `client.inbound_api.threads`: `get_list` / `get_by_id` / `delete`

Also carries the other fields that ship with the Inbound Email API:
- `EmailLogMessage`: `rfc_message_id`, `in_reply_to`, `references`, `thread_id`
- `SendingDomain`: `inbound_enabled`, `inbound_verified`
- Webhooks: `inbound_inbox_id` on `Webhook` / `CreateWebhookParams` / `UpdateWebhookParams` (for `inbound_receiving` webhooks)

## Notes

- Endpoints are token-scoped under `/api/inbound/...`; resource classes take only the HTTP client.
- Request bodies are sent flat (the v2 inbound API does not wrap params under a resource key).
- `reply` / `reply_all` / `forward` reuse `Address` and the mail `Attachment` model; `ForwardInboundMessageParams` requires at least one `to` recipient (guarded).
- Reply/forward params share a private base (`ReplyInboundMessageParams`, `ForwardInboundMessageParams`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Inbound Email API support for managing folders, inboxes, messages, and threads.
  * Added inbound message replies, reply-all, forwarding, deletion, and pagination.
  * Added inbound email models, attachment handling, threading details, and webhook integration.
* **Documentation**
  * Added Inbound Email API usage examples and README guidance.
* **Tests**
  * Added comprehensive coverage for inbound APIs, models, pagination, validation, and error handling.
* **Chores**
  * Updated examples to read API tokens from the `MAILTRAP_API_TOKEN` environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->